### PR TITLE
Update 2014-07-17-deprecating-the-switch-statement-for-object-literals.md

### DIFF
--- a/_posts/2014-07-17-deprecating-the-switch-statement-for-object-literals.md
+++ b/_posts/2014-07-17-deprecating-the-switch-statement-for-object-literals.md
@@ -258,7 +258,7 @@ case 'crisps':
   snack = 'Food';
   break;
 default:
-  drink = 'Unknown type!';
+  snack = 'Unknown type!';
 }
 console.log(snack); // 'Drink'
 {% endhighlight %}


### PR DESCRIPTION
The default case should assign to the `snack`.  Don't think `drink` is part of this example.