### PR TITLE
Add xml_escape to post.title on feed.xml

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -16,7 +16,7 @@ layout: nil
 	
 	{% for post in site.posts limit: 6 %}
 	<entry>
-		<title>{{ post.title }}</title>
+		<title>{{ post.title | xml_escape }}</title>
 		<link href="http://www.toddmotto.com{{ post.url }}" />
 		<updated>{{ post.date | date_to_xmlschema }}</updated>
 		<id>http://toddmotto.com{{ post.id }}</id>


### PR DESCRIPTION
Hello Todd,

As I see the feed.xml is broken on your site http://toddmotto.com/feed.xml I think that happens because there is no xml_escape on post.title.

![screen shot 2015-04-23 at 12 03 14 am](https://cloud.githubusercontent.com/assets/1225343/7285288/2b93a5f2-e94c-11e4-8044-da588cc36c20.png)

I think the fix is trivial and only requires to add the escaper.

P.S. Thanks a lot for all your posts on JS and Angular. They rock!
