### PR TITLE
fix(various posts): Fix typos

### DIFF
--- a/_posts/2012-12-10-mark-goodyear-on-moving-past-ie7-with-browserblast-plugin.md
+++ b/_posts/2012-12-10-mark-goodyear-on-moving-past-ie7-with-browserblast-plugin.md
@@ -94,7 +94,7 @@ $(function() {
     background: '#FAF4AF', // Background color of banner
     textColor: '#333', // Text color
     fontSize: '12px', // Font size
-    fontFamily: 'sans-serif', // Font familiy
+    fontFamily: 'sans-serif', // Font family
     borderSize: '2', // Border size
     borderStyle: 'solid', // Border style
     borderColor: '#D4C790', // Border color

--- a/_posts/2013-02-02-creating-jquery-style-functions-in-javascript-hasclass-addclass-removeclass-toggleclass.md
+++ b/_posts/2013-02-02-creating-jquery-style-functions-in-javascript-hasclass-addclass-removeclass-toggleclass.md
@@ -13,7 +13,7 @@ tags:
 
 #### UPDATE: Check out [Apollo.js](/apollo-js-standalone-class-manipulation-api-for-html5-and-legacy-dom/), the latest version of these scripts integrated with HTML APIs, the most powerful class API on the web!
 
-jQuery is a pretty cool framework, it has it’s uses, it’s pretty reliable, but remember: it’s written with JavaScript. It’s not a language by itself, it’s not a magical tool, nor the answer to our prayers. It doesn’t make front-end animation/AJAX/DOM maniuplating easy, it makes you think less and miss out on vital knowledgable. What happened before jQuery?
+jQuery is a pretty cool framework, it has it’s uses, it’s pretty reliable, but remember: it’s written with JavaScript. It’s not a language by itself, it’s not a magical tool, nor the answer to our prayers. It doesn’t make front-end animation/AJAX/DOM manipulating easy, it makes you think less and miss out on vital knowledgable. What happened before jQuery?
 
 <div class="download-box">
     <a href="//toddmotto.com/labs/reusable-js" onclick="_gaq.push(['_trackEvent', 'Click', 'Demo Reusable JS, 'Reusable JS Demo']);">Demo</a>

--- a/_posts/2013-02-25-using-html5-geolocation-to-show-current-location-with-google-maps-api.md
+++ b/_posts/2013-02-25-using-html5-geolocation-to-show-current-location-with-google-maps-api.md
@@ -32,7 +32,7 @@ Here's how we would gather our current position using JavaScript's getCurrentPos
 navigator.geolocation.getCurrentPosition();
 {% endhighlight %}
 
-We then need to hook this up with our Longtitude and Latitude:
+We then need to hook this up with our Longitude and Latitude:
 
 {% highlight javascript %}
 var latitude = position.coords.latitude;
@@ -105,7 +105,7 @@ Merging a simple Google maps basepoint and hooking it into our Geolocation, we a
 })();
 {% endhighlight %}
 
-Walking through the function, we run the feature detection, declare the map options, then feed off the navigator to create the location stamp and other details we need. You'll see I've also included some &lt;h1&gt; and &lt;h2&gt; tags for showing the user where we are in terms of exact Longtitude/Latitude using the JavaScript position co-ordinates. These co-ordinates are then created as a variable and passed into Google Maps API's setCenter method, plotting us on the map where we are!
+Walking through the function, we run the feature detection, declare the map options, then feed off the navigator to create the location stamp and other details we need. You'll see I've also included some &lt;h1&gt; and &lt;h2&gt; tags for showing the user where we are in terms of exact Longitude/Latitude using the JavaScript position co-ordinates. These co-ordinates are then created as a variable and passed into Google Maps API's setCenter method, plotting us on the map where we are!
 
 ### Handling errors
 Should Geolocation fail, or the service be unavailable, we should ideally provide some sort of notification. I haven't done it in this in my example, but here's how you can target different error codes:

--- a/_posts/2013-03-01-progressively-enhanced-svg-sprite-icons.md
+++ b/_posts/2013-03-01-progressively-enhanced-svg-sprite-icons.md
@@ -83,7 +83,7 @@ When you get your hands on CSS3, it's amazing, you can make everything super-sli
 }
 {% endhighlight %}
 
-After each CSS3 declaration on each button name, the CSS was huge. But at the time it didn't really bother me as it was all about diving into CSS3 - but it should have; as performance, speed and managability should be at the forefront of each piece of code you write. Taking this knowledge, I've come up with a better way to do this using the opacity property which is applied to each icon.
+After each CSS3 declaration on each button name, the CSS was huge. But at the time it didn't really bother me as it was all about diving into CSS3 - but it should have; as performance, speed and manageability should be at the forefront of each piece of code you write. Taking this knowledge, I've come up with a better way to do this using the opacity property which is applied to each icon.
 
 This is done like so:
 {% highlight css %}

--- a/_posts/2013-03-07-writing-the-best-css-when-building-with-html5.md
+++ b/_posts/2013-03-07-writing-the-best-css-when-building-with-html5.md
@@ -94,7 +94,7 @@ Using qualified selectors, you can then target the HTML like so:
 header {}
 {% endhighlight %}
 
-Looking at it now, this was really bad. I never do this anymore due to the life of real world development. Briefs change, goalposts move, I've had clients back out from using HTML5 elements back to HTML4, and had to make painstaking (and unncessary) changes to both my HTML _and_ CSS.
+Looking at it now, this was really bad. I never do this anymore due to the life of real world development. Briefs change, goalposts move, I've had clients back out from using HTML5 elements back to HTML4, and had to make painstaking (and unnecessary) changes to both my HTML _and_ CSS.
 
 With HTML agnostic coding, you can become much more efficient and use your classes. Nothing will change apart from your HTML. CSS is not HTML5 at the end of the day, so you shouldn't write code for it. Let HTML do it's job, and let CSS do it's job.
 

--- a/_posts/2013-05-28-iide-immediate-invoked-data-expressions-data-init-and-using-html5-to-call-your-javascript-jquery.md
+++ b/_posts/2013-05-28-iide-immediate-invoked-data-expressions-data-init-and-using-html5-to-call-your-javascript-jquery.md
@@ -81,7 +81,7 @@ It's derived from JavaScript for representing data structures and arrays and obj
 </div>
 {% endhighlight %}
 
-This is fine, but what about when the website scales, or you want to change your view (HTML)? If you add or change a class name, you're going to have to add it to each, which is repetitive work and uneccessary. For a simple slider this is fine, but it's not maintainable when you're thinking big or HTML agnostic development.
+This is fine, but what about when the website scales, or you want to change your view (HTML)? If you add or change a class name, you're going to have to add it to each, which is repetitive work and unnecessary. For a simple slider this is fine, but it's not maintainable when you're thinking big or HTML agnostic development.
 
 Coming back to JSON now, let's use HTML5 data-&#42; attributes to define an array of images inside a JSON array. The beauty of JSON arrays/objects is that they can be manually typed (like I have below), or dynamically fed down from a server - perfect for so many use cases.
 

--- a/_posts/2013-11-09-apollo-js-standalone-class-manipulation-api-for-html5-and-legacy-dom.md
+++ b/_posts/2013-11-09-apollo-js-standalone-class-manipulation-api-for-html5-and-legacy-dom.md
@@ -54,7 +54,7 @@ Apollo.hasClass(element, className);
 When I first wrote the APIs to allow you to create your own class manipulation functions, I used some _while_ loops, and the implementation was good, not great. I'm going to look at the _removeClass_ function now, and show you the difference in the new API.
 
 #### Old API:
-The old API was complex, but worked fantastically. It's important to note than when using a library that handles classes, that it actually removes _all_ instances and doesn't assume the class exists just onces.
+The old API was complex, but worked fantastically. It's important to note than when using a library that handles classes, that it actually removes _all_ instances and doesn't assume the class exists just once.
 
 {% highlight javascript %}
 function hasClass(elem, className) {

--- a/_posts/2013-12-29-everything-you-wanted-to-know-about-javascript-scope.md
+++ b/_posts/2013-12-29-everything-you-wanted-to-know-about-javascript-scope.md
@@ -291,7 +291,7 @@ myFunction.call(scope); // invoke myFunction using .call()
 {% endhighlight %}
 
 #### .bind()
-Unlike the above, using `.bind()` does not _invoke_ a function, it merely binds the values before the function is invoked. It's a real shame this was introduced in ECMASCript 5 and not earlier as this method is fantastic. As you know we can't pass parameters into function references, something like this:
+Unlike the above, using `.bind()` does not _invoke_ a function, it merely binds the values before the function is invoked. It's a real shame this was introduced in ECMAScript 5 and not earlier as this method is fantastic. As you know we can't pass parameters into function references, something like this:
 
 {% highlight javascript %}
 // works

--- a/_posts/2014-01-29-mastering-the-module-pattern.md
+++ b/_posts/2014-01-29-mastering-the-module-pattern.md
@@ -106,7 +106,7 @@ var Module = (function () {
     publicMethodOne: function () {
       // I can call `privateMethod()` you know...
     },
-    publicMethodtwo: function () {
+    publicMethodTwo: function () {
 
     },
     publicMethodThree: function () {
@@ -138,7 +138,7 @@ var Module = (function () {
 })();
 {% endhighlight %}
 
-You'll then see on the last line inside the Module that `myObject` is returned. Our global `Module` doesn't care that the locally scoped `Object` has a name, we'll only get the actualy Object sent back, not the name. It offers for better code management.
+You'll then see on the last line inside the Module that `myObject` is returned. Our global `Module` doesn't care that the locally scoped `Object` has a name, we'll only get the actual Object sent back, not the name. It offers for better code management.
 
 ### Stacked locally scoped Object Literal
 

--- a/_posts/2014-06-11-all-about-angulars-emit-broadcast-on-publish-subscribing.md
+++ b/_posts/2014-06-11-all-about-angulars-emit-broadcast-on-publish-subscribing.md
@@ -96,7 +96,7 @@ To demonstrate how `$scope` works when firing the events, here's a simple hierar
 </div>
 {% endhighlight %}
 
-If `SiblingTwoCtrl` fired `$scope.$broadcast`, then `SiblineOneCtrl` would _never_ know it happened. This can be an annoyance, but a (slightly hacky-feely) remedy can be done:
+If `SiblingTwoCtrl` fired `$scope.$broadcast`, then `SiblingOneCtrl` would _never_ know it happened. This can be an annoyance, but a (slightly hacky-feely) remedy can be done:
 
 {% highlight javascript %}
 $scope.$parent.$broadcast('myevent', 'Some data');


### PR DESCRIPTION
I'm still hacking on that automated tool :wink: 

`Font familiy` => `Font family`
`DOM maniuplating` => `DOM manipulating`
`Longtitude and Latitude` => `Longitude and Latitude`
`Longtitude/Latitude` => `Longitude/Latitude`
`speed and managability` => `speed and manageability`
`unncessary` => `unnecessary`
`uneccessary` => `unnecessary`
`exists just onces` => `exists just once`
`ECMASCript 5` => `ECMAScript 5`
`publicMethodtwo` => `publicMethodTwo`
`the actualy Object` => `the actual Object`
`SiblineOneCtrl` => `SiblingOneCtrl`

