### PR TITLE
Added missing counterChange.emit() in outputs: ['counterChange:change'] example

### DIFF
--- a/_posts/2016-03-19-component-events-event-emitter-output-angular-2.md
+++ b/_posts/2016-03-19-component-events-event-emitter-output-angular-2.md
@@ -305,9 +305,15 @@ export class CounterComponent {
   public counterValue = 0;
   increment() {
     this.counterValue++;
+    this.counterChange.emit({
+      value: this.counterValue
+    })
   }
   decrement() {
     this.counterValue--;
+    this.counterChange.emit({
+      value: this.counterValue
+    })
   }
 }
 {% endhighlight %}


### PR DESCRIPTION
Added missing counterChange.emit() in outputs: ['counterChange:change'] example