### PR TITLE
Remove apostrophes from possessive `its`

### DIFF
--- a/_posts/2012-12-03-bouncethis-plugin-mimics-css3-keyframes-bouncing-header-animations.md
+++ b/_posts/2012-12-03-bouncethis-plugin-mimics-css3-keyframes-bouncing-header-animations.md
@@ -97,7 +97,7 @@ First we start off by creating the plugin, using a semi-colon as a safety net fo
       $this.wrap('<div class="bounceThis" />');
       
       // Target our newly created element, give it the exact height as the targeted element
-      // We do this to mimic it's physical space when animating
+      // We do this to mimic its physical space when animating
       // Position it relative, to setup more relative positioning on the child element
       $('.bounceThis').css({
         height: itemheight,

--- a/_posts/2013-01-01-creating-a-responsive-dynamic-mobile-navigation-from-pure-javascript.md
+++ b/_posts/2013-01-01-creating-a-responsive-dynamic-mobile-navigation-from-pure-javascript.md
@@ -289,7 +289,7 @@ Include the script inside your  tag, and call the function just before the closi
 </html>
 {% endhighlight %}
 
-If you are using a DOM ready function handler or putting scripts before the closing body tag, then you can of course remove the script entirely from it's function wrap, and add it like this:
+If you are using a DOM ready function handler or putting scripts before the closing body tag, then you can of course remove the script entirely from its function wrap, and add it like this:
 
 {% highlight javascript %}
 var select = document.createElement('select');

--- a/_posts/2013-01-22-fluid-and-responsive-youtube-and-vimeo-videos-with-fluidvids-js.md
+++ b/_posts/2013-01-22-fluid-and-responsive-youtube-and-vimeo-videos-with-fluidvids-js.md
@@ -206,7 +206,7 @@ Here's what our finished script looks like. The things we've been able to achiev
 
 ### Usage
 
-Just drop the JavaScript file into your page (this needs to be placed before the closing &lt;/body&gt; tag or inside a DOM ready function wrapper) and let it work it's magic. No config required. Minified version also included in the download.
+Just drop the JavaScript file into your page (this needs to be placed before the closing &lt;/body&gt; tag or inside a DOM ready function wrapper) and let it work its magic. No config required. Minified version also included in the download.
 
 ### Browser Compatibility
 

--- a/_posts/2013-03-01-progressively-enhanced-svg-sprite-icons.md
+++ b/_posts/2013-03-01-progressively-enhanced-svg-sprite-icons.md
@@ -66,7 +66,7 @@ Let's create some markup then, minimising the HTML as much as possible, but maki
 <a href="#" class="s-icon s-icon-twitter"></a>
 {% endhighlight %}
 
-This is OOCSS at it's most minimal form, adding a separate class (with some nice naming conventions to show relationship between classes) to help with the construction of the element. The markup is minimal in this instance, helping us easily maintain it in the CSS. Previously, I used an &lt;img&gt; tag for each button, which would result in lots of HTTP requests to download each image.
+This is OOCSS at its most minimal form, adding a separate class (with some nice naming conventions to show relationship between classes) to help with the construction of the element. The markup is minimal in this instance, helping us easily maintain it in the CSS. Previously, I used an &lt;img&gt; tag for each button, which would result in lots of HTTP requests to download each image.
 
 ### Better CSS techniques, enhanced performance
 When you get your hands on CSS3, it's amazing, you can make everything super-slick, colourful and looking like a PhotoShop design in seconds. I admittedly went overboard with my previous set of buttons, creating triple the amount of code that I should have. I created a generic state, a hover, and active for each icon, which looked like so:

--- a/_posts/2013-03-05-attaching-event-handlers-to-dynamically-created-javascript-elements.md
+++ b/_posts/2013-03-05-attaching-event-handlers-to-dynamically-created-javascript-elements.md
@@ -120,7 +120,7 @@ li.onclick = dynamicEvent; // Attach the event!
 All done. But let's put it into a more practical use. "What can I use it for?" - anything! I ran into this when creating jResize and my browser-based responsive development tool (though I cheated a bit with jQuery so here's the JavaScript way).
 
 ### Practical usage
-In the demo I've setup, you'll see the existing list of items, give one or two a click and watch the text change and a nice icon appear. Voila! Now, the next step is to create your own element, which I've created a nice little script and small form to do exactly that. Simply type a word into the field input, and generate your element. The newly created element will be born with it's onclick function attached.
+In the demo I've setup, you'll see the existing list of items, give one or two a click and watch the text change and a nice icon appear. Voila! Now, the next step is to create your own element, which I've created a nice little script and small form to do exactly that. Simply type a word into the field input, and generate your element. The newly created element will be born with its onclick function attached.
 
 ### Keeping functions outside the loop
 JSLint likes to remind everyone that you shouldn't create functions inside a loop, in some cases it's okay to do, but for this tutorial I totally agree. It will save us from writing duplicated markup when running the function on both the static and dynamically created elements (which is why dynamicEvent is created outside the loop and simply called).

--- a/_posts/2013-03-07-writing-the-best-css-when-building-with-html5.md
+++ b/_posts/2013-03-07-writing-the-best-css-when-building-with-html5.md
@@ -96,7 +96,7 @@ header {}
 
 Looking at it now, this was really bad. I never do this anymore due to the life of real world development. Briefs change, goalposts move, I've had clients back out from using HTML5 elements back to HTML4, and had to make painstaking (and unnecessary) changes to both my HTML _and_ CSS.
 
-With HTML agnostic coding, you can become much more efficient and use your classes. Nothing will change apart from your HTML. CSS is not HTML5 at the end of the day, so you shouldn't write code for it. Let HTML do it's job, and let CSS do it's job.
+With HTML agnostic coding, you can become much more efficient and use your classes. Nothing will change apart from your HTML. CSS is not HTML5 at the end of the day, so you shouldn't write code for it. Let HTML do its job, and let CSS do its job.
 
 Here's a much better way of targeting the &lt;header&gt; element:
 
@@ -115,7 +115,7 @@ We can then become free of relying on our markup for styling like so:
 And what happens if we need to revert back to using the well-known &lt;div&gt;? Easy switch back. This isn't the only practicality for this method of coding for HTML5…
 
 ### Avoiding qualified name selectors
-A lot of developers like to add the qualified name to CSS selectors, this again has no real point to it as the CSS should be specific enough to do it's job properly. Here's an example of using a qualified name alongside a CSS selector:
+A lot of developers like to add the qualified name to CSS selectors, this again has no real point to it as the CSS should be specific enough to do its job properly. Here's an example of using a qualified name alongside a CSS selector:
 
 {% highlight css %}
 header.header {}

--- a/_posts/2013-03-14-storing-data-in-the-browser-with-the-html5-local-storage-api.md
+++ b/_posts/2013-03-14-storing-data-in-the-browser-with-the-html5-local-storage-api.md
@@ -177,7 +177,7 @@ Putting the above together, we can create a really simple localStorage app that 
 })();
 {% endhighlight %}
 
-The above function is a really simple usage of the localStorage API, but you can see it's potential. If you visit the demo, type anything you want and providing your browser supports HTML5 localStorage, you can refresh the page as much as you want, close the browser and come back to it - and it'll still be there. If your browser doesn't support it, you'll get a note saying so.
+The above function is a really simple usage of the localStorage API, but you can see its potential. If you visit the demo, type anything you want and providing your browser supports HTML5 localStorage, you can refresh the page as much as you want, close the browser and come back to it - and it'll still be there. If your browser doesn't support it, you'll get a note saying so.
 
 ### Browser support
 The web storage API was implemented a few years back now, and as such was integrated into IE8 (and obviously IE9). This makes it even better when working with it, as we can all start to move away from supporting IE7. IE8 is actually a blessing on a few levels compared to IE7, it's still a massively popular browser world-wide, but it supports things like querySelector, localStorage, and also CSS such as box-sizing:border-box - all things modern development thrives upon. It's not all doom and gloom, see the silver linings.

--- a/_posts/2013-05-20-progressively-enhancing-html5-forms-creating-a-required-attribute-fallback-with-jquery.md
+++ b/_posts/2013-05-20-progressively-enhancing-html5-forms-creating-a-required-attribute-fallback-with-jquery.md
@@ -148,7 +148,7 @@ $('[required]').each(function () {
 {% endhighlight %}
 
 ### Form submission
-Attributes are all setup now for form submission, which of course will only fire if a _required_ class exists, meaning we don't need to do another feature check and can simply include a _$('.required')_ selector inside the form handler. Let's look at how we can set that up. Our form has a class of 'form' for simplicity and is the only markup-reliant selector our script will need, the rest will automatically do it's magic.
+Attributes are all setup now for form submission, which of course will only fire if a _required_ class exists, meaning we don't need to do another feature check and can simply include a _$('.required')_ selector inside the form handler. Let's look at how we can set that up. Our form has a class of 'form' for simplicity and is the only markup-reliant selector our script will need, the rest will automatically do its magic.
 
 {% highlight javascript %}
 $('.form').on('submit', function () {

--- a/_posts/2013-05-30-revisiting-svg-workflow-for-performance-and-progressive-development-with-transparent-data-uris.md
+++ b/_posts/2013-05-30-revisiting-svg-workflow-for-performance-and-progressive-development-with-transparent-data-uris.md
@@ -78,7 +78,7 @@ I really liked this as it suddenly made some sense in a crazy way. The _blank.gi
 The above 'Google' technique I like to explain to others as a transparent window image with a background image, essentially you're looking through a transparent image to see a background image. This is also amazing for icons...
 
 ### Why a clear &lt;img&gt; tag, over the &lt;i&gt; element for icons?
-I've stopped using &lt;i&gt; for icons, it really isn't a good element. It's semantic meaning is that the contents should be italic, yes it starts with 'i' for 'icon' so I assume this is why it's popularity has risen, but it's semantic use is incorrect and it should be swapped for the _blank.gif_ technique, as really - icons are images too.
+I've stopped using &lt;i&gt; for icons, it really isn't a good element. Its semantic meaning is that the contents should be italic, yes it starts with 'i' for 'icon' so I assume this is why its popularity has risen, but its semantic use is incorrect and it should be swapped for the _blank.gif_ technique, as really - icons are images too.
 
 ### Data URIs
 Instead of using a _blank.gif_ physical image, we could trump Google a little and create a transparent Data URI image out of it, and embed the image data inline. This is done to save uploading and creating a transparent image as well as to save an HTTP request:
@@ -120,7 +120,7 @@ So far, I've covered a better SVG detect, and a better way to use icons and imag
 {% endhighlight %}
 
 ### Script before Style (just this time)
-Advancing from the above markup, the &lt;html&gt; tag has an _svg_ class and the feature detect comes _before_ the &lt;style&gt; tag. You've probably been slapped on the wrist before for putting scripts before styles (please never do this with _.js_ files!) - but for feature detects this is perfect. The script is not running on document ready (DOM ready) as we want to run it as fast as possible and get the feature detect result for the CSS to do it's thing.
+Advancing from the above markup, the &lt;html&gt; tag has an _svg_ class and the feature detect comes _before_ the &lt;style&gt; tag. You've probably been slapped on the wrist before for putting scripts before styles (please never do this with _.js_ files!) - but for feature detects this is perfect. The script is not running on document ready (DOM ready) as we want to run it as fast as possible and get the feature detect result for the CSS to do its thing.
 
 When we now add SVG, this will benefit our performance too. If SVG is supported, the SVG override in the CSS will take action _before_ the PNG fallback is loaded, meaning this saves an HTTP request and pointless image download. We don't want to load extra images and override them with prettier SVGs - just one is a perfect scenario.
 

--- a/_posts/2013-06-25-is-it-time-to-drop-jquery-essentials-to-learning-javascript-from-a-jquery-background.md
+++ b/_posts/2013-06-25-is-it-time-to-drop-jquery-essentials-to-learning-javascript-from-a-jquery-background.md
@@ -9,17 +9,17 @@ tags:
 - JavaScript
 ---
 
-jQuery has been a godsend to pretty much all of us front-end developers since it's release, it's intuitive methods, easy functions make light work of JavaScript's loosely typed language. JavaScript is hard, it's hard to get into, it's much harder than jQuery. But the time is nearly here, going native is going to be the future of front-end - HTML5.
+jQuery has been a godsend to pretty much all of us front-end developers since its release, its intuitive methods, easy functions make light work of JavaScript's loosely typed language. JavaScript is hard, it's hard to get into, it's much harder than jQuery. But the time is nearly here, going native is going to be the future of front-end - HTML5.
 
 HTML5 doesn't just mean a few extra HTML elements, if you're putting down on your CV/Resume that you know HTML5 because you've used the new elements, then think again! HTML5 covers such a mass of technology, and also alongside it comes ECMAScript 5, the future of JavaScript. Combining HTML5 APIs, of which most require JavaScript, we need to adopt a more native structure of working as each day jQuery becomes less important, and here's why.
 
 This article takes a jQuery lover through some of the harder, more misunderstood, JavaScript methods, functions and more to show how native technology has caught up, how it's not as difficult as it seems and that native JavaScript is probably going to hit you like a brick in the face fairly soon - if it hasn't already. As a front-end developer I am pretty passionate about knowing my tech, and admittedly I began with jQuery and moved to learning JavaScript, I know many others have too. This article is here to talk anyone looking to dive into native JavaScript development over jQuery, and should hopefully open up some doors into the future of your coding.
 
 ### Selectors
-jQuery selectors are the big seller, we don't even have to think about it, selecting our elements is a no brainer, it's super simple. jQuery uses Sizzle, an engine also created by the jQuery Foundation (but available as a standalone) to use as it's selector engine. The mighty code behind Sizzle will make you think twice before overcomplicating your selectors, and the raw JavaScript alternative will make you think twice about jQuery altogether!
+jQuery selectors are the big seller, we don't even have to think about it, selecting our elements is a no brainer, it's super simple. jQuery uses Sizzle, an engine also created by the jQuery Foundation (but available as a standalone) to use as its selector engine. The mighty code behind Sizzle will make you think twice before overcomplicating your selectors, and the raw JavaScript alternative will make you think twice about jQuery altogether!
 
 #### Class selectors
-JavaScript had no native _className_ method for grabbing elements with classes until fairly recent, which I feel has hindered it's popularity from the start. Classes are the best for our HTML/CSS development, but weren't well supported with native JavaScript - makes sense not to want to 'learn JavaScript' and go with jQuery. Until now.
+JavaScript had no native _className_ method for grabbing elements with classes until fairly recent, which I feel has hindered its popularity from the start. Classes are the best for our HTML/CSS development, but weren't well supported with native JavaScript - makes sense not to want to 'learn JavaScript' and go with jQuery. Until now.
 
 Let's look at the options:
 {% highlight javascript %}
@@ -58,7 +58,7 @@ document.getElementsByTagName('div');
 {% endhighlight %}
 
 #### querySelector/querySelectorAll
-This is where things heat up - enter querySelector. Had it not been for jQuery, querySelector may not have made it's way into the JavaScript language as quickly or as efficiently as it has - so we have jQuery to thank for this.
+This is where things heat up - enter querySelector. Had it not been for jQuery, querySelector may not have made its way into the JavaScript language as quickly or as efficiently as it has - so we have jQuery to thank for this.
 
 The magic behind querySelector is astounding, it's a multi-purpose native tool that you can use in various instances (this is raw JavaScript). There are two types of querySelector, the first which is plain old _document.querySelector('')_ returns the first Node in the NodeList, regardless of how many Node Objects it might find. The second, ultimately the best and most powerful is _document.querySelectorAll('')_ which returns a NodeList every time. I've been using _document.querySelectorAll('')_ as standard as it's easier to grab the first item in the returned NodeList than it is to reverse engineer _document.querySelector('')_.
 

--- a/_posts/2013-07-20-psswrd-the-show-hide-password-javascript-plugin.md
+++ b/_posts/2013-07-20-psswrd-the-show-hide-password-javascript-plugin.md
@@ -10,7 +10,7 @@ tags:
 
 Show/hide toggling for password inputs. Psswrd is a neat little script I've put together to aid in better user experience when users are completing your forms or actioning things inside web apps. For instance, instead of another irritating 'confirm password' field, we provide a 'show password' for them to double-check before signing up, logging in, filling out various 'secret questions', or whatever else you can think of.
 
-Psswrd is a small script (1KB minified) that does exactly that. It's also really easy to integrate. It might not be an everyday usage script, but it certainly has it's place. At the minute, there are no simple to integrate scripts that are written in raw JavaScript, most are jQuery dependent - so I wanted to mix it up and go all out on raw JS.
+Psswrd is a small script (1KB minified) that does exactly that. It's also really easy to integrate. It might not be an everyday usage script, but it certainly has its place. At the minute, there are no simple to integrate scripts that are written in raw JavaScript, most are jQuery dependent - so I wanted to mix it up and go all out on raw JS.
 
 <div class="download-box">
   <a href="//toddmotto.com/labs/psswrd" onclick="_gaq.push(['_trackEvent', 'Click', 'Demo Psswrd', 'Psswrd Demo']);">Demo</a>

--- a/_posts/2013-07-28-hacking-the-html5-video-element-with-suave-js.md
+++ b/_posts/2013-07-28-hacking-the-html5-video-element-with-suave-js.md
@@ -41,7 +41,7 @@ So here's where Suave comes in. Thanks to my little script, you no longer have t
 <video data-src="video/mymovie.{mp4, ogv, webm}"></video>
 {% endhighlight %}
 
-All you need to do is feed it the file extensions you require for each video inside a _data-*_ attribute, easy. Suave is fully modular as well, call it as many times on the page and it'll just keep doing it's thing. What I also like about this solution is that I'm enhancing HTML5, _with_ HTML5. Of course some people will disagree and say I'm missing a few codecs, lost my mind and am hashing out strange ideas, but my project would be finished ontime and save countless future hours.
+All you need to do is feed it the file extensions you require for each video inside a _data-*_ attribute, easy. Suave is fully modular as well, call it as many times on the page and it'll just keep doing its thing. What I also like about this solution is that I'm enhancing HTML5, _with_ HTML5. Of course some people will disagree and say I'm missing a few codecs, lost my mind and am hashing out strange ideas, but my project would be finished ontime and save countless future hours.
 
 I've been using Grunt.js a lot recently and I love how you can simply include some curly braces to say 'or this too', so that's where the idea came from to simplify an overcomplicated system. This is fully semantic stuff too, if anything this improves the semantics of the &lt;video&gt; tag! With the current HTML5 spec, if you only have one HTML format, you can do this:
 

--- a/_posts/2013-08-11-echo-js-simple-javascript-image-lazy-loading.md
+++ b/_posts/2013-08-11-echo-js-simple-javascript-image-lazy-loading.md
@@ -31,7 +31,7 @@ Here's the markup to specify the image source, which is literal so you'll be abl
 <img src="img/blank.gif" alt="" data-echo="img/album-1.jpg">
 {% endhighlight %}
 
-Just drop the script into your page before the closing _&lt;/body&gt;_ tag and let it do it's thing. For modern browsers I've used the _DOMContentLoaded_ event incase you _really_ need it in the _&lt;head&gt;_, which is a native 'DOM Ready', and a fallback to onload for IE7/8 if you need to go that far so all works nicely.
+Just drop the script into your page before the closing _&lt;/body&gt;_ tag and let it do its thing. For modern browsers I've used the _DOMContentLoaded_ event incase you _really_ need it in the _&lt;head&gt;_, which is a native 'DOM Ready', and a fallback to onload for IE7/8 if you need to go that far so all works nicely.
 
 ### JavaScript
 As always, I'll talk through the script for those interested in the behind the scenes working. Here's the full script:
@@ -193,7 +193,7 @@ var echoImages = function () {
 };
 {% endhighlight %}
 
-The OO piece of the script looks inside the _prototype_ extension, which has a few functions inside. The first is the _init()_ function, that simply pushes the current element into our data store array. The _render()_ function checks to see if an _addEventListener_ event exists, which will then invoke the _echoImages_ function once the _DOMContentLoaded_ event is fired. If it doesn't exist, likely inside IE7/8, it'll just run _onload_. The _listen()_ function will just run the function again each time the window is scrolled, to poll and see if any elements come into view to work it's magic some more.
+The OO piece of the script looks inside the _prototype_ extension, which has a few functions inside. The first is the _init()_ function, that simply pushes the current element into our data store array. The _render()_ function checks to see if an _addEventListener_ event exists, which will then invoke the _echoImages_ function once the _DOMContentLoaded_ event is fired. If it doesn't exist, likely inside IE7/8, it'll just run _onload_. The _listen()_ function will just run the function again each time the window is scrolled, to poll and see if any elements come into view to work its magic some more.
 
 {% highlight javascript %}
 Echo.prototype = {

--- a/_posts/2013-09-21-the-data-js-api-for-behavioural-binding-stop-using-selectors-in-your-javascript.md
+++ b/_posts/2013-09-21-the-data-js-api-for-behavioural-binding-stop-using-selectors-in-your-javascript.md
@@ -24,7 +24,7 @@ I'm going to show you how to:
 The behavioural-binding concept is binding repeating behaviours to DOM elements, instead of selecting elements and manipulating them. In a sense, it's what you're not used to doing. Probably:
 
 _Previously_; you targeted an element, wrapped it in a function and did some DOM wizardry.
-_Now_; you write your JavaScript logic independent of elements, and bind the behaviours with `data-*` attributes. The implementation is quite similar, but the thinking behind it is the separation key and how you'll need to think ahead for all future elements and not tie your JS so closely to your HTML. Behavioural-binding doesn't care what element it is, it'll just do it's thing (if it's a valid method).
+_Now_; you write your JavaScript logic independent of elements, and bind the behaviours with `data-*` attributes. The implementation is quite similar, but the thinking behind it is the separation key and how you'll need to think ahead for all future elements and not tie your JS so closely to your HTML. Behavioural-binding doesn't care what element it is, it'll just do its thing (if it's a valid method).
 
 ### Reuse and the problem scenario
 The initial problem with DOM logic and JavaScript binding is simple, take three inputs for example with different classes:
@@ -184,7 +184,7 @@ $('div.className > ul:first-child li.className').on('click', function () {
 });
 {% endhighlight %}
 
-It happens all the time, and jQuery's amazing selector engine Sizzle promotes it's power, which is vastly abused by so many developers. Of course when you're learning, you don't know any different. I mean, when I faced challenges in DOM selectors and JavaScript logic in early days I'd duplicate a script and just change a selector to get it to work twice - crazy looking back at it.
+It happens all the time, and jQuery's amazing selector engine Sizzle promotes its power, which is vastly abused by so many developers. Of course when you're learning, you don't know any different. I mean, when I faced challenges in DOM selectors and JavaScript logic in early days I'd duplicate a script and just change a selector to get it to work twice - crazy looking back at it.
 
 If you're writing JavaScript with selector vomit you probably shouldn't be writing it at all. JavaScript provides functionality, it shouldn't be dependent on a Node somewhere in the DOM tree.
 

--- a/_posts/2013-10-02-ultimate-guide-to-learning-angular-js-in-one-day.md
+++ b/_posts/2013-10-02-ultimate-guide-to-learning-angular-js-in-one-day.md
@@ -189,7 +189,7 @@ For this exercise, I'm going to keep it really simple and create a custom type o
 
 I prefer using them as an attribute, custom elements are coming in the future of HTML5 under the Web Components, but Angular report these quite buggy in some older browsers.
 
-Now you know how to declare where Directives are used/injected, let's create this custom button. Again, I'll hook into my global namespace _myApp_ for the application, this is a directive in it's simplest form:
+Now you know how to declare where Directives are used/injected, let's create this custom button. Again, I'll hook into my global namespace _myApp_ for the application, this is a directive in its simplest form:
 
 {% highlight javascript %}
 myApp.directive('customButton', function () {
@@ -201,7 +201,7 @@ myApp.directive('customButton', function () {
 });
 {% endhighlight %}
 
-I define my directive using the _.directive()_ method, and pass in the directive's name 'customButton'. When you capitalise a letter in a Directive's name, it's use case is then split via a hyphen in the DOM (as above).
+I define my directive using the _.directive()_ method, and pass in the directive's name 'customButton'. When you capitalise a letter in a Directive's name, its use case is then split via a hyphen in the DOM (as above).
 
 A directive simply returns itself via an Object and takes a number of parameters. The most important for me to master first are, _restrict_, _replace_, _transclude_, _template_ and _templateUrl_, and of course the _link_ property. Let's add those others in:
 
@@ -372,7 +372,7 @@ Output:
 
 You can see that we passed the greeting data to a filter via the pipe (|) character, applying the reverse filter to the greeting data.
 
-And it's usage inside an _ng-repeat_:
+And its usage inside an _ng-repeat_:
 
 {% highlight html%}
 <ul>
@@ -397,7 +397,7 @@ myApp.controller('MainCtrl', ['$scope', function ($scope) {
 }]);
 {% endhighlight %}
 
-And it's usage inside an _ng-repeat_:
+And its usage inside an _ng-repeat_:
 
 {% highlight html%}
 <li ng-repeat="number in numbers | filter:greaterThanNum">
@@ -414,7 +414,7 @@ That's the main bulk behind AngularJS and its APIs, this is only diving into the
 ### Two-way data-binding
 When I first heard about two-way data-binding, I wasn't really sure what it was. Two-way data-binding is best described as a full-circle of synchronised data: update the _Model_ and it updates the _View_, update the _View_ and it updates the _Model_. This means that data is kept in sync without making any fuss. If I bind an _ng-model_ to an &lt;input&gt; and start typing, this creates (or updates an existing) model at the same time.
 
-Here I create the &lt;input&gt; and bind a Model called 'myModel', I can then use the curly handlebars syntax to reflect this model and it's updates in the view all at once:
+Here I create the &lt;input&gt; and bind a Model called 'myModel', I can then use the curly handlebars syntax to reflect this model and its updates in the view all at once:
 
 {% highlight html %}
 <div ng-app="myApp">
@@ -442,7 +442,7 @@ You've got the idea when it comes to pushing basic data to the _$scope_ now, and
 
 When you're developing locally, you're possibly using something like Java, ASP .NET, PHP or something else to run a local server. Whether you're contacting a local database or actually using the server as an API to communicate to another resource, this is much the same setup.
 
-Enter 'dollar http'. Your best friend from now on. The _$http_ method is a nice Angular wrapper for accessing data from the server, and so easy to use you could do it blindfolded. Here's a simple example of a 'GET' request, which (you guessed it) gets data from the server. It's syntax is very jQuery-like so transitioning is a breeze:
+Enter 'dollar http'. Your best friend from now on. The _$http_ method is a nice Angular wrapper for accessing data from the server, and so easy to use you could do it blindfolded. Here's a simple example of a 'GET' request, which (you guessed it) gets data from the server. Its syntax is very jQuery-like so transitioning is a breeze:
 
 {% highlight javascript %}
 myApp.controller('MainCtrl', ['$scope', '$http', function ($scope, $http) {
@@ -589,7 +589,7 @@ myApp.controller('MainCtrl', ['$scope', function ($scope) {
 }]);
 {% endhighlight %}
 
-Pro tip: It's important to think about deleting _data_ from the Model. You're not deleting elements or anything actual DOM related, Angular is an MVC framework and will handle all this for you with it's two-way binding and callback-free world, you just need to setup your code intelligently to let it respond to your data!
+Pro tip: It's important to think about deleting _data_ from the Model. You're not deleting elements or anything actual DOM related, Angular is an MVC framework and will handle all this for you with its two-way binding and callback-free world, you just need to setup your code intelligently to let it respond to your data!
 
 Binding functions to the scope are also run through _ng-*_ Directives, this time it's an _ng-click_ Directive:
 
@@ -697,7 +697,7 @@ We could then have _emails.html_ simply loaded with our HTML which generates our
 There is a lot more to the _$routeProvider_ service which is well worth reading up on, but this'll get the ball rolling for you. There are things such as _$http_ interceptors that'll fire events when an Ajax call is in progress, things we could show some spinners for whilst we load in fresh data.
 
 ### Global static data
-Gmail handles a lot of it's initial data by writing the JSON into the page (right-click View Source). If you want to instantly set data in your page, it'll quicken up rendering time and Angular will hit the ground running.
+Gmail handles a lot of its initial data by writing the JSON into the page (right-click View Source). If you want to instantly set data in your page, it'll quicken up rendering time and Angular will hit the ground running.
 
 When I develop our apps, Java tags are placed in the DOM and when rendered, the data is sent down from the backend. [I've zero experience with Java so you'll get a made up declaration from me below, you could use any language though on the server.] Here's how to write JSON into your page and then pass it into a Controller for immediate binding use:
 

--- a/_posts/2013-10-07-creating-an-angularjs-directive-from-one-of-your-existing-plugins-scripts.md
+++ b/_posts/2013-10-07-creating-an-angularjs-directive-from-one-of-your-existing-plugins-scripts.md
@@ -16,7 +16,7 @@ No _DOM manipulation_ should be carried out inside a Controller, the Controller 
 
 So here's how to migrate one of your existing scripts or plugins across into a tightly coded AngularJS directive, this also makes code readability and reuse ultra-efficient, as Directives take the strain of repetitive code out the window.
 
-Directives are Angular's answer to Web Components 'Shadow DOM' but are compatible in all browsers (not just cutting edge HTML5 supporting ones) - bringing you the power of the future technology, today. Shadow DOM injects new content based on the element, has it's own CSS and JavaScript scope and introduces some incredible behaviour mechanisms, and this is what Directives mimic to bring you this technology today.
+Directives are Angular's answer to Web Components 'Shadow DOM' but are compatible in all browsers (not just cutting edge HTML5 supporting ones) - bringing you the power of the future technology, today. Shadow DOM injects new content based on the element, has its own CSS and JavaScript scope and introduces some incredible behaviour mechanisms, and this is what Directives mimic to bring you this technology today.
 
 <div class="download-box">
   <a href="//toddmotto.com/labs/fluidvids-angular">Demo</a>

--- a/_posts/2013-10-27-hacking-svg-traversing-with-ease-addclass-removeclass-toggleclass-functions.md
+++ b/_posts/2013-10-27-hacking-svg-traversing-with-ease-addclass-removeclass-toggleclass-functions.md
@@ -15,7 +15,7 @@ tags:
 
 I encountered how painful traversing inline SVG can be when working on a recent project, simple DOM APIs such as adding, removing and toggling classes just aren't there, or supported by tools such as jQuery (yes, I even tried jQuery).
 
-Inline SVG is SVG in the DOM, rendered from it's XML. Here's a quick look at example inline SVG which would sit anywhere in the DOM:
+Inline SVG is SVG in the DOM, rendered from its XML. Here's a quick look at example inline SVG which would sit anywhere in the DOM:
 
 {% highlight html %}
 <svg id="svg" xmlns="http://www.w3.org/2000/svg" version="1.1" height="190">
@@ -32,7 +32,7 @@ var mySVG = document.querySelector('#svg');
 
 ### Problem: DOM stuff
 
-But the problem begins when trying to do the 'usual' DOM stuff, adding a class, or removing a class. You'd think it would be pretty simple, but even using jQuery's APIs don't allow it to work either, so I wrote my own and I'm pretty pleased with it's compactness. The trick is to _set_ the attribute again, you can't keep adding/removing classes using the _.className_ method. The _getAttribute_ method is what I've used to grab the class attribute's value, and then the idea behind it is to grab that attribute, manipulate it and then set it back again.
+But the problem begins when trying to do the 'usual' DOM stuff, adding a class, or removing a class. You'd think it would be pretty simple, but even using jQuery's APIs don't allow it to work either, so I wrote my own and I'm pretty pleased with its compactness. The trick is to _set_ the attribute again, you can't keep adding/removing classes using the _.className_ method. The _getAttribute_ method is what I've used to grab the class attribute's value, and then the idea behind it is to grab that attribute, manipulate it and then set it back again.
 
 Let's say I have a function, I need to add a class to an SVG circle onclick:
 
@@ -53,7 +53,7 @@ mySVG.setAttribute('class', 'myClass');
 I have to think as the 'class' attribute as totally made up and that _className_ doesn't exist. And manipulating this is where the magic happens.
 
 ### hasClass API
-As with all the APIs, I'm hanging these off the SVGElement's prototype constructor so all SVG nodes inherit the methods. With _hasClass_, I'm extending the native Object with a function. This method allows simple declaration of the APIs. Inside the _hasClass_ function, I'm creating a new Regular Expression, which gets dynamically created through it's _className_ parameter and immediately tested against it's attribute value. JavaScript's _.test()_ returns a boolean (true/false), a simple way to test a class presence.
+As with all the APIs, I'm hanging these off the SVGElement's prototype constructor so all SVG nodes inherit the methods. With _hasClass_, I'm extending the native Object with a function. This method allows simple declaration of the APIs. Inside the _hasClass_ function, I'm creating a new Regular Expression, which gets dynamically created through its _className_ parameter and immediately tested against its attribute value. JavaScript's _.test()_ returns a boolean (true/false), a simple way to test a class presence.
 
 {% highlight javascript %}
 SVGElement.prototype.hasClass = function (className) {

--- a/_posts/2013-10-28-nofi-detecting-no-wifi-callbacks-for-offline-states-with-html5.md
+++ b/_posts/2013-10-28-nofi-detecting-no-wifi-callbacks-for-offline-states-with-html5.md
@@ -53,7 +53,7 @@ if ('onLine' in navigator) {
 {% endhighlight %}
 
 ### Recursive setTimeout()
-Recursive functions are awesome, and so is a recursive `setTimeout()`. Stop using `setInterval()`, these are very bad and will keep setting an interval despite whether it's finished it's operations or not. Using a recursive `setTimeout()` means all the operations inside the timeout are finished as we recursive right at the bottom, it's sexy:
+Recursive functions are awesome, and so is a recursive `setTimeout()`. Stop using `setInterval()`, these are very bad and will keep setting an interval despite whether it's finished its operations or not. Using a recursive `setTimeout()` means all the operations inside the timeout are finished as we recursive right at the bottom, it's sexy:
 
 {% highlight javascript %}
 if ('onLine' in navigator) {

--- a/_posts/2013-10-29-understanding-regular-expression-matching-with-test-match-exec-search-and-split.md
+++ b/_posts/2013-10-29-understanding-regular-expression-matching-with-test-match-exec-search-and-split.md
@@ -18,7 +18,7 @@ Here's an example of a RegExp that's intended to blow your mind if you've never 
 /^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/
 {% endhighlight %}
 
-This is infact a RegExp for matching the HTML5 email format (what the `input[type=email]` looks for in it's native validation). I'm going to cover the use cases for testing RegExps in a few ways, each with a specific use case. This will include the most popular JavaScript APIs; `.test()`, `.match()` and `.exec()`.
+This is infact a RegExp for matching the HTML5 email format (what the `input[type=email]` looks for in its native validation). I'm going to cover the use cases for testing RegExps in a few ways, each with a specific use case. This will include the most popular JavaScript APIs; `.test()`, `.match()` and `.exec()`.
 
 ### .test()
 Using `.test()` is probably my favourite method of testing RegExps, it's a beautiful API, the fastest and the simplest to use. The `.test()` API runs a search for a match between a RegExp and a String.
@@ -95,7 +95,7 @@ _Notable features/tips:_
 1. Great for splitting chunks of data
 2. Returns a new array
 
-Here's an example of splitting a string by it's RegExp equivalent of whitespace:
+Here's an example of splitting a string by its RegExp equivalent of whitespace:
 
 {% highlight javascript %}
 // returns ["Hello,", "my", "name", "is", "Todd", "Motto"]

--- a/_posts/2013-12-17-stop-toggling-classes-with-js-use-behaviour-driven-dom-manipulation-with-data-states.md
+++ b/_posts/2013-12-17-stop-toggling-classes-with-js-use-behaviour-driven-dom-manipulation-with-data-states.md
@@ -110,7 +110,7 @@ If I told you I could replicate the above, now, wouldn't that be sweet? Well, I 
 
 At first you might be thinking _"what on earth..."_
 
-But, I would say that is pretty clean, and helps us a lot with our coding. I can easily tell what the code is doing, and there are no adding or removing of classes happening here. I am merely going to be toggling the value of the data-state attribute, and the CSS will do it's work.
+But, I would say that is pretty clean, and helps us a lot with our coding. I can easily tell what the code is doing, and there are no adding or removing of classes happening here. I am merely going to be toggling the value of the data-state attribute, and the CSS will do its work.
 
 ### Toggling the data-state
 

--- a/_posts/2013-12-29-everything-you-wanted-to-know-about-javascript-scope.md
+++ b/_posts/2013-12-29-everything-you-wanted-to-know-about-javascript-scope.md
@@ -98,7 +98,7 @@ var myFunction = function () {
 };
 {% endhighlight %}
 
-You'll notice that `myOtherFunction` _isn't_ being called here, it's simply defined. It's order of call also has effect on how the scoped variables react, here I've defined my function and called it _under_ another `console` statement:
+You'll notice that `myOtherFunction` _isn't_ being called here, it's simply defined. Its order of call also has effect on how the scoped variables react, here I've defined my function and called it _under_ another `console` statement:
 
 {% highlight javascript %}
 var myFunction = function () {
@@ -181,7 +181,7 @@ Okay, I lied, you _can_ call it, and you may have seen functions like this, but 
 sayHello('Bob')(); // calls the returned function without assignment
 {% endhighlight %}
 
-AngularJS uses the above technique for it's `$compile` method, where you pass the current scope reference into the closure:
+AngularJS uses the above technique for its `$compile` method, where you pass the current scope reference into the closure:
 
 {% highlight javascript %}
 $compile(template)(scope);

--- a/_posts/2014-01-19-avoiding-anonymous-javascript-functions.md
+++ b/_posts/2014-01-19-avoiding-anonymous-javascript-functions.md
@@ -172,7 +172,7 @@ element.addEventListener('click', toggleMenu(param1, param2), false);
 element.addEventListener('click', toggleMenu.bind(null, param1, param2), false);
 {% endhighlight %}
 
-You can read more about `.bind()` [here](/everything-you-wanted-to-know-about-javascript-scope) and [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind).You can grab the `.bind()` [polyfill here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind) so that all browsers can use `.bind()` (as it's current IE9+ and all modern browsers)
+You can read more about `.bind()` [here](/everything-you-wanted-to-know-about-javascript-scope) and [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind). You can grab the `.bind()` [polyfill here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind) so that all browsers can use `.bind()` (as it's current IE9+ and all modern browsers).
 
 If you don't want to polyfill and go "oldschool" then you'll need to wrap it inside a function:
 

--- a/_posts/2014-03-31-writing-a-standalone-ajax-xhr-javascript-micro-library.md
+++ b/_posts/2014-03-31-writing-a-standalone-ajax-xhr-javascript-micro-library.md
@@ -309,7 +309,7 @@ So working from what we've already got above, I created some chained methods for
 });
 {% endhighlight %}
 
-Using atomic.js is just as easy as any other library, except it's got a very readable syntax, it's less than 1KB, and punches well above it's weight in functionality.
+Using atomic.js is just as easy as any other library, except it's got a very readable syntax, it's less than 1KB, and punches well above its weight in functionality.
 
 I've got some ideas planned for the future development of atomic, and of course feel free to help out!
 

--- a/_posts/2014-04-12-understanding-the-this-keyword-in-javascript.md
+++ b/_posts/2014-04-12-understanding-the-this-keyword-in-javascript.md
@@ -49,7 +49,7 @@ myFunction();
 
 #### Object literals
 
-Inside Object literals, the `this` value will always refer to it's own Object. Nice and simple to remember. That is good news when invoking our functions, and one of the reasons I adopt patterns such as the module pattern for organising my objects.
+Inside Object literals, the `this` value will always refer to its own Object. Nice and simple to remember. That is good news when invoking our functions, and one of the reasons I adopt patterns such as the module pattern for organising my objects.
 
 Here's how that might look:
 

--- a/_posts/2014-05-14-simple-foreach-implementation-for-objects-nodelists-arrays-with-automatic-type-looping.md
+++ b/_posts/2014-05-14-simple-foreach-implementation-for-objects-nodelists-arrays-with-automatic-type-looping.md
@@ -26,7 +26,7 @@ So I did...
 
 ### forEach.js
 
-`forEach.js` is a simple script, it's not part of a library or even a module, it's just a function, here's it's syntax and a quick example using an `Array`:
+`forEach.js` is a simple script, it's not part of a library or even a module, it's just a function, here's its syntax and a quick example using an `Array`:
 
 {% highlight javascript %}
 // syntax

--- a/_posts/2014-06-09-rethinking-angular-js-controllers.md
+++ b/_posts/2014-06-09-rethinking-angular-js-controllers.md
@@ -249,7 +249,7 @@ I've been chatting with [Jonathan](https://twitter.com/jcreamer898) recently on 
 
 We kind of agreed on a mix of both and that there are many options and opinions. We also agreed that using `Controller as` mixed with the above approach is superb architecture for Angular. The word "Model" might not be completely correct on what I'm describing above, business logic might be another word, but to keep things easy I've stuck with "Model".
 
-Jasmine/Karma unit testing is made much easier as well, we can test the Factory to ensure it's hitting all it's endpoints, fetching and updating the local data - and when testing the Controller we can go in knowing our Factory is bulletproof which will help us track down errors faster, and make our Controller tests even slimmer.
+Jasmine/Karma unit testing is made much easier as well, we can test the Factory to ensure it's hitting all its endpoints, fetching and updating the local data - and when testing the Controller we can go in knowing our Factory is bulletproof which will help us track down errors faster, and make our Controller tests even slimmer.
 
 ### Using $scope
 

--- a/_posts/2014-06-17-minimal-angular-module-syntax-approach-using-an-iife.md
+++ b/_posts/2014-06-17-minimal-angular-module-syntax-approach-using-an-iife.md
@@ -84,7 +84,7 @@ app.controller('MainCtrl',
 });
 {% endhighlight %}
 
-So what about moving it outside into it's own function to make Angular less visible and my JavaScript more "standalone":
+So what about moving it outside into its own function to make Angular less visible and my JavaScript more "standalone":
 
 {% highlight javascript %}
 function MainCtrl ($scope, SomeFactory) {

--- a/_posts/2014-06-30-methods-to-determine-if-an-object-has-a-given-property.md
+++ b/_posts/2014-06-30-methods-to-determine-if-an-object-has-a-given-property.md
@@ -11,7 +11,7 @@ tags:
 There are multiple ways to detect whether an Object has a property. You'd think it'd be as easy as `myObject.hasOwnProperty('prop');` - but no, there are a few different ways with their own problems and gotchas. Let's look at the few ways to check property existence, concepts that confuse JavaScript developers, prototype chain lookups and problems JavaScript might provide us.
 
 ### Double bang !! property lookup
-We've all seen it, probably in something such as Modernizr for simple feature detection, the infamous `!!` amongst our JS. Important note before we begin this one, it doesn't actually check if an Object has a property "as such", it checks the _value_ of the Object property. Which means if the property value is false, or the object property doesn't even exist, they give the same `falsy` result - which can be really bad if you use it without knowing what it does and it's limitations.
+We've all seen it, probably in something such as Modernizr for simple feature detection, the infamous `!!` amongst our JS. Important note before we begin this one, it doesn't actually check if an Object has a property "as such", it checks the _value_ of the Object property. Which means if the property value is false, or the object property doesn't even exist, they give the same `falsy` result - which can be really bad if you use it without knowing what it does and its limitations.
 
 #### What does it mean?
 

--- a/_posts/2014-07-02-web-components-concepts-shadow-dom-imports-templates-custom-elements.md
+++ b/_posts/2014-07-02-web-components-concepts-shadow-dom-imports-templates-custom-elements.md
@@ -15,7 +15,7 @@ Before I get into Polymer, we'll look at Web Components in this post, what it me
 
 Gone are the days of actually creating HTML structures and "pages" (what're those?). The web is becoming "all about components", and those components are completely up to us thanks to Web Components.
 
-We aren't really at a stage where we can use Web Components to it's fullest, browser support is still ongoing implementations and IE are [in consideration](http://status.modern.ie) of the entire spec (blows a single fanfare). But it's coming together, give it a few years and we'll get there. Or do we have to wait that long?...
+We aren't really at a stage where we can use Web Components to its fullest, browser support is still ongoing implementations and IE are [in consideration](http://status.modern.ie) of the entire spec (blows a single fanfare). But it's coming together, give it a few years and we'll get there. Or do we have to wait that long?...
 
 Google are innovating in this area like no tomorrow with [Polymer.js](http://www.polymer-project.org), a polyfill and platform (that provides additional features such as data-binding, event callbacks and much more) for those missing pieces in modern browsers that don't fully support Web Components.
 
@@ -50,7 +50,7 @@ template.querySelector('.profile__social').textContent = 'Follow me on Twitter';
 document.body.appendChild(template);
 {% endhighlight %}
 
-You'll notice that this is just JavaScript, no new APIs or anything confusing. Nice! For me, a `<template>` is useless without it's good buddy _Custom Elements_. We need this to do something useful with the tech, things are all global and disgusting as of now.
+You'll notice that this is just JavaScript, no new APIs or anything confusing. Nice! For me, a `<template>` is useless without its good buddy _Custom Elements_. We need this to do something useful with the tech, things are all global and disgusting as of now.
 
 #### Custom Elements
 Custom Elements allow us to define (you guessed it), our own element. This can be anything, but before you go crazy, your elements must have a dash, presumably to avoid any potential naming clashes with future HTML implementations - I think that's a good idea as well.
@@ -110,7 +110,7 @@ window.MyElement = document.registerElement('user-profile', {
 New elements must inherit from the `HTMLElement.prototype`. More on the above setup and callbacks etc [here](https://github.com/webcomponents/hello-world-element/blob/master/src/hello-world.html), cheers [Zeno](//twitter.com/zenorocha).
 
 ##### Extending and inheriting
-What if we wanted to extend an existing element, such as an `<h1>` tag? There will be many cases of this, such as riding off an existing element and creating a "special" version of it, rather than a totally new element. We introduce the `{ extends: '' }` property to declare where what element we're extending. Using an extended element is simple, drop the `is=""` attribute on an existing element and it'll inherit it's new extension. Pretty simple, I guess.
+What if we wanted to extend an existing element, such as an `<h1>` tag? There will be many cases of this, such as riding off an existing element and creating a "special" version of it, rather than a totally new element. We introduce the `{ extends: '' }` property to declare where what element we're extending. Using an extended element is simple, drop the `is=""` attribute on an existing element and it'll inherit its new extension. Pretty simple, I guess.
 
 {% highlight html %}
 <template>

--- a/_posts/2014-07-11-angular-js-dependency-injection-annotation-process.md
+++ b/_posts/2014-07-11-angular-js-dependency-injection-annotation-process.md
@@ -60,7 +60,7 @@ angular
   }]);
 {% endhighlight %}
 
-[John Papa](//twitter.com/John_Papa) and I have been discussing the first pattern in depth recently and advocate it's use over the latter, that's another story though.
+[John Papa](//twitter.com/John_Papa) and I have been discussing the first pattern in depth recently and advocate its use over the latter, that's another story though.
 
 #### 3. $inject
 

--- a/_posts/2015-04-14-es6-arrow-functions-syntaxes-and-lexical-scoping.md
+++ b/_posts/2015-04-14-es6-arrow-functions-syntaxes-and-lexical-scoping.md
@@ -9,7 +9,7 @@ tags:
 - JavaScript
 ---
 
-ES2015 (ES6) introduces a really nice feature that punches above it's weight in terms of simplicity to integrate versus time saving and feature output. This feature is the arrow function.
+ES2015 (ES6) introduces a really nice feature that punches above its weight in terms of simplicity to integrate versus time saving and feature output. This feature is the arrow function.
 
 Before we dive into the features of the arrow function and what it actually does for us, let's understand what an arrow function is _not_. It's not a replacement for the `function` keyword, at all. This means you can't do a find and replace on every single `function` keyword and everything works perfectly, because it likely won't.
 
@@ -109,7 +109,7 @@ numbers.map((number) => number * 2);
 {% endhighlight %}
 
 ### Functionality: lexical scoping "this"
-Now we're past the sugar syntax excitement, we can dig into the benefits of the arrow function and it's implications on execution context.
+Now we're past the sugar syntax excitement, we can dig into the benefits of the arrow function and its implications on execution context.
 
 Typically if we're writing ES5, we'll use something like `Function.prototype.bind` to grab the `this` value from another scope to change a function's execution context. This will mainly be used in callbacks inside a different scope.
 

--- a/_posts/2015-04-20-a-better-way-to-scope-angular-extend-no-more-vm-this.md
+++ b/_posts/2015-04-20-a-better-way-to-scope-angular-extend-no-more-vm-this.md
@@ -40,7 +40,7 @@ angular
 
 This pattern is great (and has other variations such as binding `vm.doSomething = function () {}` directly without declaring the function above and assigning), and has been really helpful in working with Angular. The reason `vm` was created was to help with referencing the correct context inside other functions, as `this` doesn't follow the lexical scoping rules like other variables do, so we assign `this` to `vm` to make a "reference".
 
-When you start having to bind a lot of things, we repeat `vm` so many times and end up with `vm.*` references all over our code. We don't really need to bind directly to the `this` value, JavaScript can work on it's own (such as updating `var foo = {};` locally in a callback rather than `vm.foo`) for instance. An example with lots of `vm.*` bindings:
+When you start having to bind a lot of things, we repeat `vm` so many times and end up with `vm.*` references all over our code. We don't really need to bind directly to the `this` value, JavaScript can work on its own (such as updating `var foo = {};` locally in a callback rather than `vm.foo`) for instance. An example with lots of `vm.*` bindings:
 
 {% highlight javascript %}
 function MainCtrl () {

--- a/_posts/2015-12-07-angular-component-method-back-ported-to-1.3.md
+++ b/_posts/2015-12-07-angular-component-method-back-ported-to-1.3.md
@@ -157,7 +157,7 @@ function identifierForController(controller, ident) {
 
 ### Patching "bindToController"
 
-The `bindToController` property was introduced in Angular 1.3, however it's value was limited to a Boolean until 1.4. If we wanted to use it, we would declare `bindToController: true` on the Directive definition Object. This means we had to use `scope: { prop: '=' }` when accessing inherited members. In Angular 1.4, we could use `scope: {}, bindToController: { prop: '=' }` and move our bindings to the `bindToController` property to be more explicit in saying "I want to bind these to a Controller". This is just syntax sugar, and obviously Angular 1.3 doesn't support an Object as the value of `bindToController`, so this needed to change.
+The `bindToController` property was introduced in Angular 1.3, however its value was limited to a Boolean until 1.4. If we wanted to use it, we would declare `bindToController: true` on the Directive definition Object. This means we had to use `scope: { prop: '=' }` when accessing inherited members. In Angular 1.4, we could use `scope: {}, bindToController: { prop: '=' }` and move our bindings to the `bindToController` property to be more explicit in saying "I want to bind these to a Controller". This is just syntax sugar, and obviously Angular 1.3 doesn't support an Object as the value of `bindToController`, so this needed to change.
 
 Underneath it's identical, and it's also under a wrapper as we use `bindings` inside the `component()` method, so it doesn't really matter how we do the underlying detection and bindings.
 

--- a/_posts/2015-12-14-directive-to-directive-communication-with-require.md
+++ b/_posts/2015-12-14-directive-to-directive-communication-with-require.md
@@ -79,7 +79,7 @@ angular
   .directive('tabs', tabs);
 {% endhighlight %}
 
-The Controller now has an `addTab` method bound. But how do we add a tab? We need to get started with adding the child `tab` Directive, and require it's Controller functionality:
+The Controller now has an `addTab` method bound. But how do we add a tab? We need to get started with adding the child `tab` Directive, and require its Controller functionality:
 
 {% highlight javascript %}
 function tab() {
@@ -107,7 +107,7 @@ angular
   .directive('tabs', tabs);
 {% endhighlight %}
 
-We've successfully used `require: '^tabs'` to include the parent `tabs` Directive's Controller, so we now have access to it's functionality through the `link` function. We need to now inject a fourth argument, `$ctrl`, to get our Controller reference:
+We've successfully used `require: '^tabs'` to include the parent `tabs` Directive's Controller, so we now have access to its functionality through the `link` function. We need to now inject a fourth argument, `$ctrl`, to get our Controller reference:
 
 {% highlight javascript %}
 function tab() {

--- a/_posts/2015-12-15-use-controller-filters-to-prevent-digest-performance-issues.md
+++ b/_posts/2015-12-15-use-controller-filters-to-prevent-digest-performance-issues.md
@@ -63,7 +63,7 @@ angular
   .filter('testFilter', testFilter);
 {% endhighlight %}
 
-This majestic `testFilter` will be bound to an `ng-repeat`, and each time the filter is called, it'll increment it's internal counter and log it out in the console for us.
+This majestic `testFilter` will be bound to an `ng-repeat`, and each time the filter is called, it'll increment its internal counter and log it out in the console for us.
 
 We can add it to the `ng-repeat` like so:
 

--- a/_posts/2015-12-28-creating-a-tabs-component-with-react.md
+++ b/_posts/2015-12-28-creating-a-tabs-component-with-react.md
@@ -51,7 +51,7 @@ I've added the `displayName: 'Tabs'` to help with JSX's debugging (JSX will set 
 
 Next up I've added the `render` function that returns the chunk of HTML I need.
 
-Now it's time to show the tab's contents passed through. I'll create a "private" method on the Class, it won't actually be private but it's naming convention with the underscore prefix will let me know it is.
+Now it's time to show the tab's contents passed through. I'll create a "private" method on the Class, it won't actually be private but its naming convention with the underscore prefix will let me know it is.
 
 {% highlight javascript %}
 const Tabs = React.createClass({
@@ -318,7 +318,7 @@ const Pane = React.createClass({
 
 ### propTypes validation
 
-React is absolutely fantastic with it's debugging error messages, and we can improve that inline by using `propTypes` and the relevant validation of the type. Let's start with the tab component:
+React is absolutely fantastic with its debugging error messages, and we can improve that inline by using `propTypes` and the relevant validation of the type. Let's start with the tab component:
 
 {% highlight javascript %}
 const Tabs = React.createClass({

--- a/_posts/2016-02-05-one-way-data-binding-in-angular-1-5.md
+++ b/_posts/2016-02-05-one-way-data-binding-in-angular-1-5.md
@@ -5,7 +5,7 @@ title: One-way data-binding in Angular 1.5
 path: 2016-02-05-one-way-data-binding-in-angular-1-5.md
 ---
 
-Angular is known for it's powerful two-way data-binding, but with the new release of Angular 1.5, we've got one-way data binding (one-directional) binding capabilities inside our Components and Directives. Woohoo! Let's explore to see what it does, and doesn't, give us to develop with.
+Angular is known for its powerful two-way data-binding, but with the new release of Angular 1.5, we've got one-way data binding (one-directional) binding capabilities inside our Components and Directives. Woohoo! Let's explore to see what it does, and doesn't, give us to develop with.
 
 ### First impressions
 

--- a/_posts/2016-03-17-creating-an-angular-2-component.md
+++ b/_posts/2016-03-17-creating-an-angular-2-component.md
@@ -13,7 +13,7 @@ Before creating your first Component however, you'll need to learn how to [Boots
 
 ### Creating a Component with @Component
 
-In Angular 2, there's a heavy push and recommendation towards using TypeScript and it's superset features, in this case we're going to be using TypeScript and it's decorators (such as `@Component`), which are just functions prefixed with an `@` symbol.
+In Angular 2, there's a heavy push and recommendation towards using TypeScript and its superset features, in this case we're going to be using TypeScript and its decorators (such as `@Component`), which are just functions prefixed with an `@` symbol.
 
 First thing after bootstrapping your application, we'll need to import some funky stuff from Angular's core. Let's create a file called `app.component.ts` and add some boilerplate code:
 

--- a/_posts/2016-04-01-angular-3-alpha.md
+++ b/_posts/2016-04-01-angular-3-alpha.md
@@ -7,7 +7,7 @@ path: 2016-04-01-angular-3-alpha.md
 
 <img src="/img/posts/angular-3.jpg">
 
-Austin ([@amcdnl](https://twitter.com/amcdnl)) and I are huge Angular 1.x and 2.x fans, and have taken some time out to get some behind the scenes scoop on the Angular 3 developments. The Google team have been working long and hard at delivering Angular 2, and with it's imminent release, we're excited about the Angular 3 developments. Here's the lowdown on things to come in 2017.
+Austin ([@amcdnl](https://twitter.com/amcdnl)) and I are huge Angular 1.x and 2.x fans, and have taken some time out to get some behind the scenes scoop on the Angular 3 developments. The Google team have been working long and hard at delivering Angular 2, and with its imminent release, we're excited about the Angular 3 developments. Here's the lowdown on things to come in 2017.
 
 [ This was an April fools joke, read on with that in mind :) ]
 

--- a/_posts/2016-06-03-lifecycle-hooks.md
+++ b/_posts/2016-06-03-lifecycle-hooks.md
@@ -92,7 +92,7 @@ Because the lifecycles are well-defined (and well-timed in execution order) we c
 
 First what we'd have to do though, is use `require`, I've written a more in-depth post on using [$onInit and require](/on-init-require-object-syntax-angular-component/), but let's cover some basics here too and provide a real world example after.
 
-Let's take our `myComponent` example and use `require` in it's new Object form (only for `.component()`, when using `require` with `.directive()` you can still use an Array or String syntax for requiring controllers):
+Let's take our `myComponent` example and use `require` in its new Object form (only for `.component()`, when using `require` with `.directive()` you can still use an Array or String syntax for requiring controllers):
 
 {% highlight javascript %}
 var myComponent = {


### PR DESCRIPTION
Hi Todd, just a grammar sweep. I removed the apostrophes from `it's` when they aren't being used as contractions. Thanks so much for all of your work. You're a big inspiration.