### PR TITLE
Fix todo id computation

### DIFF
--- a/_posts/2016-10-12-stateful-stateless-components-missing-manual.md
+++ b/_posts/2016-10-12-stateful-stateless-components-missing-manual.md
@@ -168,7 +168,7 @@ export class TodosComponent implements OnInit {
     this.todos = this.todoService.getTodos();
   }
   addTodo({label}) {
-    this.todos = [{label, id: this.todos.length + 1}, ...this.todos];
+    this.todos = [{label, id: Date.now().toString()}, ...this.todos];
   }
   completeTodo({todo}) {
     this.todos = this.todos.map(
@@ -364,7 +364,7 @@ const todos = {
       this.todos = this.todoService.getTodos();
     }
     addTodo({ label }) {
-      this.todos = [{ label, id: this.todos.length + 1 }, ...this.todos];
+      this.todos = [{ label, id: Date.now().toString() }, ...this.todos];
     }
     completeTodo({ todo }) {
       this.todos = this.todos.map(


### PR DESCRIPTION
Thanks a lot for this post ! Stateless and stateful are really easy to understand that way.
Just a little thing though, using the array length as the base for defining id of new todos create an issue.

If you delete any other todo than the last one, the next will be created with the same id as the current last. So when you complete or delete one, the other is affected as well. 

It's not really important to demonstrate stateless and stateful but maybe it could be changed to something related to current Datetime ?

And also, if you think this solution is not a bad idea, it would need be changed in the plunker :)
