### PR TITLE
It's just Angular! :tada:

### DIFF
--- a/_posts/2015-10-27-walkthrough-to-upgrade-an-angular-1-component-to-angular-2.md
+++ b/_posts/2015-10-27-walkthrough-to-upgrade-an-angular-1-component-to-angular-2.md
@@ -8,13 +8,11 @@ tags:
 - Angular 2
 ---
 
-In this article we're going to look at upgrading your first Angular 1.x component, a simple todo app, across to Angular 2 code. We'll compare the API differences, templating syntaxes and hopefully it'll shed some light on upgrading to Angular 2, and well as making it appear less daunting.
+In this article we're going to look at upgrading your first AngularJS (1.x) component, a simple todo app, across to Angular (v2+) code. We'll compare the API differences, templating syntaxes and hopefully it'll shed some light on upgrading to Angular, and well as making it appear less daunting.
 
-_Please note: Angular 2 is still in "alpha" state, so APIs/conventions may be subject to change, however I will aim to keep this article and the working code updated._
+### AngularJS Todo App
 
-### Angular 1.x Todo App
-
-We'll be rewriting this small component in Angular 2, so let's look at the existing functionality:
+We'll be rewriting this small component in Angular, so let's look at the existing functionality:
 
 * Add items to todo list
 * Ability to delete items
@@ -39,7 +37,7 @@ function todo() {
       // set an empty Model for the <input>
       this.label = '';
       // have some dummy data for the todo list
-      // complete property with Boolean values to display 
+      // complete property with Boolean values to display
       // finished todos
       this.todos = [{
         label: 'Learn Angular',
@@ -82,7 +80,7 @@ function todo() {
         event.preventDefault();
       };
     },
-    // instantiate the Controller as "vm" to namespace the 
+    // instantiate the Controller as "vm" to namespace the
     // Class-like Object
     controllerAs: 'vm',
     // our HTML template
@@ -135,7 +133,7 @@ The app is complete below:
 
 One of the design patterns I highly recommend is using the `controllerAs` syntax ([see my article here on it](http://toddmotto.com/digging-into-angulars-controller-as-syntax)) inside the Directive definition, this allows our Controllers to be free of injecting `$scope` and adopt a more "Class-like" way of writing Controllers. We use the `this` keyword to create public methods which then gets bound to the `$scope` automatically by Angular at runtime.
 
-Using `controllerAs`, IMO, is a crucial step to preparing Angular 1.x components for migration to Angular 2, as the way we write components in Angular 2 uses the `this` keyword on an Object definition for our public methods.
+Using `controllerAs`, IMO, is a crucial step to preparing AngularJS components for migration to Angular, as the way we write components in Angular uses the `this` keyword on an Object definition for our public methods.
 
 ### Project setup/bootstrapping
 
@@ -143,9 +141,9 @@ Files to include, and boostrapping the application.
 
 ##### Angular 1.x
 
-We're going to walk through every single part of the setup of Angular 1.x versus Angular 2, from bootstrapping the application to creating the component, so follow closely.
+We're going to walk through every single part of the setup of AngularJS versus Angular, from bootstrapping the application to creating the component, so follow closely.
 
-We have the basic HTML page, including version `1.4.7` of Angular, and manually bootstrapping the application using `angular.bootstrap`.
+We have the basic HTML page, including version `1.4.7` of AngularJS, and manually bootstrapping the application using `angular.bootstrap`.
 
 {% highlight html %}
 <!doctype html>
@@ -165,15 +163,15 @@ We have the basic HTML page, including version `1.4.7` of Angular, and manually 
 
 {% endhighlight %}
 
-##### Angular 2
+##### Angular
 
-We're going to actually create the Angular 2 application component in ES5, there will be no ES6 and TypeScript because this will let you write Angular 2 in the browser with ease, and also the final working example is using ES5 running in JSFiddle.
+We're going to actually create the Angular application component in ES5, there will be no ES6 and TypeScript because this will let you write Angular in the browser with ease, and also the final working example is using ES5 running in JSFiddle.
 
 There will, however, be the TypeScript/ES6 example at the end to demonstrate the full migration from 1.x to ES5, then the final ES6 + TypeScript solution.
 
-First we need to include Angular 2, I'm not going to `npm install` or mess about installing dependencies, how-to steps are on the [angular.io](https://angular.io/docs/ts/latest/quickstart.html) website. Let's get up and running and learn the framework basics and migrate our Angular 1.x app.
+First we need to include Angular, I'm not going to `npm install` or mess about installing dependencies, how-to steps are on the [angular.io](https://angular.io/docs/ts/latest/quickstart.html) website. Let's get up and running and learn the framework basics and migrate our AngularJS app.
 
-First, we need to include Angular 2 in the `<head>`, you'll notice I'm using `angular2.sfx.dev.js` from version `2.0.0-alpha.44`. This `.sfx.` means it's the self-executing bundled version, targeted at ES5 use without System loader polyfills, so we don't need to add `System.js` to our project.
+First, we need to include Angular in the `<head>`; you'll notice I'm using `angular2.sfx.dev.js` from version `2.0.0-alpha.44`. This `.sfx.` means it's the self-executing bundled version, targeted at ES5 use without System loader polyfills, so we don't need to add `System.js` to our project.
 
 {% highlight html %}
 <!doctype html>
@@ -196,9 +194,9 @@ So far everything is super simple, instead of `window.angular` we have `window.n
 
 ### Component definition
 
-Upgrading the Directive to an Angular 2 component.
+Upgrading the Directive to an Angular component.
 
-##### Angular 1.x
+##### AngularJS
 
 Stripping out all the JavaScript Controller logic from the Directive leaves us with something like this:
 
@@ -217,11 +215,11 @@ angular
   .directive('todo', todo);
 {% endhighlight %}
 
-##### Angular 2
+##### Angular
 
-In Angular 2, we create a `Todo` variable, which assigns the result of `ng` to it with corresponding chained definitions (`Component`, `Class`) - these are all new in Angular 2.
+In Angular, we create a `Todo` variable, which assigns the result of `ng` to it with corresponding chained definitions (`Component`, `Class`) - these are all new in Angular.
 
-Inside `.Component()`, we tell Angular to use the `selector: 'todo'`, which is exactly the same as `.directive('todo', todo);` in Angular 1.x. We also tell Angular where to find our template, just like in Angular 1.x we use the `templateUrl` property.
+Inside `.Component()`, we tell Angular to use the `selector: 'todo'`, which is exactly the same as `.directive('todo', todo);` in AngularJS. We also tell Angular where to find our template, just like in AngularJS we use the `templateUrl` property.
 
 Finally, the `.Class()` method is what holds the logic for our component, we kick things off with a `constructor` property that acts as the "constructor" class. So far so good!
 
@@ -242,9 +240,9 @@ document.addEventListener('DOMContentLoaded', function () {
 
 ### Component logic
 
-Next, it makes sense to move our Controller logic from Angular 1.x across to Angular 2's `.Class()` method. If you've used ReactJS, this will look familiar. This is also why I suggest using `controllerAs` syntax because this process will be extremely simple to do.
+Next, it makes sense to move our Controller logic from AngularJS across to Angular's `.Class()` method. If you've used ReactJS, this will look familiar. This is also why I suggest using `controllerAs` syntax because this process will be extremely simple to do.
 
-##### Angular 1.x
+##### AngularJS
 
 Let's look what we have in our todo component already. Public methods use `this` to bind to the `$scope` Object automatically for us, and we're using `controllerAs: 'vm'` to namespace the instance of the Controller for use in the DOM.
 
@@ -283,9 +281,9 @@ controller: function () {
 controllerAs: 'vm',
 {% endhighlight %}
 
-##### Angular 2
+##### Angular
 
-Now, let's kill the Controller entirely, and move these public methods into the `.Class()` definition inside Angular 2:
+Now, let's kill the Controller entirely, and move these public methods into the `.Class()` definition inside Angular:
 
 {% highlight javascript %}
 .Class({
@@ -323,9 +321,9 @@ Now, let's kill the Controller entirely, and move these public methods into the 
 });
 {% endhighlight %}
 
-Learnings here: "public" methods become properties of the Object passed into the `.Class()` method, and we don't need to refactor any of the code because in Angular 1.x we were using the `controllerAs` syntax alongside the `this` keyword - seamless and easy.
+Learnings here: "public" methods become properties of the Object passed into the `.Class()` method, and we don't need to refactor any of the code because in AngularJS we were using the `controllerAs` syntax alongside the `this` keyword - seamless and easy.
 
-At this stage, the component will work, however the template we have is completely based off Angular 1.x Directives, so we need to update this.
+At this stage, the component will work, however the template we have is completely based off AngularJS Directives, so we need to update this.
 
 ### Template migration
 
@@ -359,14 +357,14 @@ Here's the entire template that we need to migrate to the new syntax:
 Let's be smart and attack this in chunks though, keeping only the functional pieces we need. Starting with the `<form>`:
 
 {% highlight html %}
-<!-- Angular 1.x -->
+<!-- AngularJS -->
 <form ng-submit="vm.onSubmit($event);">
 
 </form>
 
-<!-- Angular 2 -->
+<!-- Angular -->
 <form (submit)="onSubmit($event);">
-  
+
 </form>
 {% endhighlight %}
 
@@ -375,10 +373,10 @@ Key changes here are the new `(submit)` syntax, this indicates that an event is 
 Next up is the two-way binding on the `<input>`:
 
 {% highlight html %}
-<!-- Angular 1.x -->
+<!-- AngularJS -->
 <input ng-model="vm.label" class="todo__input">
 
-<!-- Angular 2 -->
+<!-- Angular -->
 <input [(ng-model)]="label" class="todo__input">
 {% endhighlight %}
 
@@ -399,7 +397,7 @@ This sets up two-way binding on `ng-model`, also dropping the `vm.` prefix. This
 Moving onto the list of todo items. There's quite a lot going on here, the `ng-repeat` over the todo items, a conditional `ng-class` to show items completed (crossed out), a checkbox to mark things as complete, and finally the `ng-click` binding to delete that specific todo item from the list.
 
 {% highlight html %}
-<!-- Angular 1.x -->
+<!-- AngularJS -->
 <ul class="todo__list">
   <li ng-repeat="item in vm.todos" ng-class="{
     'todo__list--complete': item.complete
@@ -412,7 +410,7 @@ Moving onto the list of todo items. There's quite a lot going on here, the `ng-r
   </li>
 </ul>
 
-<!-- Angular 2 -->
+<!-- Angular -->
 <ul class="todo__list">
   <li *ng-for="#item of todos; #i = index" [ng-class]="{
     'todo__list--complete': item.complete
@@ -428,7 +426,7 @@ Moving onto the list of todo items. There's quite a lot going on here, the `ng-r
 
 The differences here are mainly in the `ng-repeat` syntax and moving across to `ng-for`, which uses `#item of Array` syntax. Interestingly enough, `$index` isn't given to us "for free" anymore, we have to request it and assign it to a variable to gain access to it (`#i = $index`) which then allows us to pass that specific Array index into the `deleteItem` method.
 
-Altogether we have our finished Angular 2 component markup migration:
+Altogether we have our finished Angular component markup migration:
 
 {% highlight html %}
 <div class="todo">
@@ -455,7 +453,7 @@ Altogether we have our finished Angular 2 component markup migration:
 </div>
 {% endhighlight %}
 
-Altogether our Angular 2 component will look like so:
+Altogether our Angular component will look like so:
 
 {% highlight javascript %}
 var Todo = ng
@@ -538,7 +536,7 @@ And that's it! The working solution:
 
 <iframe width="100%" height="300" src="//jsfiddle.net/toddmotto/mtv8qhw5/embedded/result,js,html" allowfullscreen="allowfullscreen" frameborder="0"></iframe>
 
-Check out the [Angular 2 cheatsheet](https://angular.io/docs/ts/latest/guide/cheatsheet.html), this is extremely handy when refactoring your templates from Angular 1.x to 2.
+Check out the [Angular cheatsheet](https://angular.io/docs/ts/latest/guide/cheatsheet.html), this is extremely handy when refactoring your templates from AngularJS to Angular.
 
 ### ES6 + TypeScript version
 
@@ -602,9 +600,9 @@ We're also not using _any_ browser globals (`window.ng`) which is fantastic, all
 
 Visit [angular.io](https://angular.io) for everything else.
 
-### Steps to take now to prepare for Angular 2
+### Steps to take now to prepare for Angular
 
 * Convert your application to ES6 + TypeScript
 * Refactor any Directives using a [decoupled component](http://www.bennadel.com/blog/2922-decoupling-component-directives-from-layout-in-angularjs.htm) approach
 * Refactor any Controllers to use [controllerAs](http://toddmotto.com/digging-into-angulars-controller-as-syntax) syntax
-* [Angular 2 migration guide - ngMigrate](http://ngmigrate.telerik.com)
+* [Angular migration guide - ngMigrate](http://ngmigrate.telerik.com)

--- a/_posts/2015-11-13-exploring-the-angular-1-5-component-method.md
+++ b/_posts/2015-11-13-exploring-the-angular-1-5-component-method.md
@@ -11,15 +11,15 @@ tags:
 - Angular
 ---
 
-Angular 1.5 introduced the `.component()` helper method, which is much simpler than the `.directive()` definition and advocates best practices and common default behaviours. Using `.component()` will allow developers to write in an Angular 2 style as well, which will in turn make upgrading to Angular 2 an easier feat.
+AngularJS 1.5 introduced the `.component()` helper method, which is much simpler than the `.directive()` definition and advocates best practices and common default behaviours. Using `.component()` will allow developers to write in an Angular (v2+) style as well, which will in turn make upgrading to Angular an easier feat.
 
 Let's compare the differences in syntax and the super neat abstraction that `.component()` gives us over using the `.directive()` method.
 
-> Build an Angular 1.5 component architecture app, end-to-end with Firebase. Check out my [Angular 1.x Pro](https://ultimateangular.com/courses/#angular-1) course.
+> Build an AngularJS 1.5 component architecture app, end-to-end with Firebase. Check out my [Angular 1.x Pro](https://ultimateangular.com/courses/#angular-1) course.
 
-### Update: use component() now in Angular 1.3+
+### Update: use component() now in AngularJS 1.3+
 
-I've back-ported the Angular 1.5 `.component()` functionality to Angular 1.3 and above! [Read the article](/angular-component-method-back-ported-to-1.3) and grab the _latest_ [source code on GitHub](https://github.com/toddmotto/angular-component).
+I've back-ported the AngularJS 1.5 `.component()` functionality to AngularJS 1.3 and above! [Read the article](/angular-component-method-back-ported-to-1.3) and grab the _latest_ [source code on GitHub](https://github.com/toddmotto/angular-component).
 
 ### .directive() to .component()
 
@@ -35,7 +35,7 @@ module.component(name, options);
 
 The `name` argument is what we want to define our Component as, the `options` argument is a definition Object passed into the component, rather than a function that we know so well in versions 1.4 and below.
 
-I've prebuilt a simple `counter` component for the purposes of this exercise in Angular `1.4.x` which we'll refactor into a version `v1.5.0` build to use `.component()`.
+I've prebuilt a simple `counter` component for the purposes of this exercise in AngularJS `1.4.x` which we'll refactor into a version `v1.5.0` build to use `.component()`.
 
 {% highlight javascript %}
 .directive('counter', function counter() {
@@ -70,7 +70,7 @@ A live embed of the `1.4.x` Directive:
 
 <iframe width="100%" height="300" src="//jsfiddle.net/toddmotto/avdezer7/embedded/result,js,html" allowfullscreen="allowfullscreen" frameborder="0"></iframe>
 
-We'll continue building this alongside how we'd build the Angular 1.4 version to compare differences.
+We'll continue building this alongside how we'd build the AngularJS 1.4 version to compare differences.
 
 ### Function to Object, method name change
 
@@ -278,7 +278,7 @@ There's a subtle difference in the `template` property worth noting. Let's add t
 });
 {% endhighlight %}
 
-The `template` property can be defined as a function that is now injected with `$element` and `$attrs` locals. If the `template` property _is_ a function then it needs to return an String representing the HTML to compile:
+The `template` property can be defined as a function that is now injected with `$element` and `$attrs` locals. If the `template` property _is_ a function then it needs to return a String representing the HTML to compile:
 
 {% highlight javascript %}
 {
@@ -299,7 +299,7 @@ The `template` property can be defined as a function that is now injected with `
 
 <iframe width="100%" height="300" src="//jsfiddle.net/toddmotto/xqauz9aa/embedded/result,js,html" allowfullscreen="allowfullscreen" frameborder="0"></iframe>
 
-That's it for our Directive to Component refactor, however there are a few other changes worth exploring before we finish.
+That's it for our Directive to Component refactor; however, there are a few other changes worth exploring before we finish.
 
 ### Inheriting behaviour using "require"
 
@@ -381,7 +381,7 @@ angular
 
 ### Sourcecode for comparison
 
-Throughout the article I've referred to some Angular source code snippets to cross reference against. Here's the source code below:
+Throughout the article I've referred to some AngularJS source code snippets to cross reference against. Here's the source code below:
 
 {% highlight javascript %}
 this.component = function registerComponent(name, options) {
@@ -440,11 +440,11 @@ this.component = function registerComponent(name, options) {
 };
 {% endhighlight %}
 
-Again, please note that Angular 1.5 isn't released just yet, so this article uses an API that _may_ be subject to slight change.
+Again, please note that AngularJS 1.5 isn't released just yet, so this article uses an API that _may_ be subject to slight change.
 
-### Upgrading to Angular 2
+### Upgrading to Angular (v2+)
 
-Writing components in this style will allow you to upgrade your Components using `.component()` into Angular 2 very easily, it'd look something like this in ECMAScript 5 and new template syntax:
+Writing components in this style will allow you to upgrade your Components using `.component()` into Angular very easily, it'd look something like this in ECMAScript 5 and new template syntax:
 
 {% highlight javascript %}
 import {Component} from '@angular/core';
@@ -453,7 +453,7 @@ import {Component} from '@angular/core';
   selector: 'counter',
   template: `
     <div class="todo">
-      <input type="text" [(ng-model)]="count">
+      <input type="text" [(ngModel)]="count">
       <button type="button" (click)="decrement();">-</button>
       <button type="button" (click)="increment();">+</button>
     </div>
@@ -461,7 +461,7 @@ import {Component} from '@angular/core';
 })
 export default class CounterComponent {
   constructor() {
-    
+
   }
   increment() {
     this.count++;

--- a/_posts/2015-12-07-angular-component-method-back-ported-to-1.3.md
+++ b/_posts/2015-12-07-angular-component-method-back-ported-to-1.3.md
@@ -11,27 +11,27 @@ tags:
 - Angular
 ---
 
-Angular 1.5 is soon to release the `component()` method which [I wrote about last month](/exploring-the-angular-1-5-component-method). I decided to back-port the functionality from the new feature so anyone running Angular 1.3 and above can start using `component()` right now. It's 100% ported from the upcoming 1.5 release so the API is identical.
+AngularJS 1.5 is soon to release the `component()` method which [I wrote about last month](/exploring-the-angular-1-5-component-method). I decided to back-port the functionality from the new feature so anyone running AngularJS 1.3 and above can start using `component()` right now. It's 100% ported from the upcoming 1.5 release so the API is identical.
 
 Grab the [source code here](https://github.com/toddmotto/angular-component) and use `component()` today.
 
-Here's a live example running `component()` with Angular 1.3.0:
+Here's a live example running `component()` with AngularJS 1.3.0:
 
 <iframe width="100%" height="300" src="//jsfiddle.net/toddmotto/wwzeo0sv/embedded/result,js,html" allowfullscreen="allowfullscreen" frameborder="0"></iframe>
 
 ### Why make this change?
 
-The Angular component code on GitHub will work directly the same as Angular 1.5's implementation, so you can upgrade to using `component()` right now before a major version upgrade, such as jumping from 1.3 to 1.5.
+The Angular component code on GitHub will work directly the same as AngularJS 1.5's implementation, so you can upgrade to using `component()` right now before a major version upgrade, such as jumping from 1.3 to 1.5.
 
-Once you're levelled up with Angular 1.5, you can simply remove the `angular-component.js` script and your app will continue working exactly the same.
+Once you're levelled up with AngularJS 1.5, you can simply remove the `angular-component.js` script and your app will continue working exactly the same.
 
-Angular 2 is getting closer and closer, a minor refactor to using `controllerAs`, `bindToController`, ditching `$scope` and writing in a component style will help you massively when upgrading your application to Angular 2.
+Angular (v2+) is here; a minor refactor to using `controllerAs`, `bindToController`, ditching `$scope` and writing in a component style will help you massively when upgrading your application to Angular.
 
 For anyone interested in how the script works, I'll walk through the code.
 
-### Hacking the Angular core
+### Hacking the AngularJS core
 
-First, I had to hack into the Angular core:
+First, I had to hack into the AngularJS core:
 
 {% highlight javascript %}
 var ng = angular.module;
@@ -48,7 +48,7 @@ function module() {
 angular.module = module;
 {% endhighlight %}
 
-These are the key players in hooking into the Angular core and adding another method. The annotated version:
+These are the key players in hooking into the AngularJS core and adding another method. The annotated version:
 
 {% highlight javascript %}
 // save a reference to angular.module
@@ -157,7 +157,7 @@ function identifierForController(controller, ident) {
 
 ### Patching "bindToController"
 
-The `bindToController` property was introduced in Angular 1.3, however its value was limited to a Boolean until 1.4. If we wanted to use it, we would declare `bindToController: true` on the Directive definition Object. This means we had to use `scope: { prop: '=' }` when accessing inherited members. In Angular 1.4, we could use `scope: {}, bindToController: { prop: '=' }` and move our bindings to the `bindToController` property to be more explicit in saying "I want to bind these to a Controller". This is just syntax sugar, and obviously Angular 1.3 doesn't support an Object as the value of `bindToController`, so this needed to change.
+The `bindToController` property was introduced in AngularJS 1.3, however its value was limited to a Boolean until 1.4. If we wanted to use it, we would declare `bindToController: true` on the Directive definition Object. This means we had to use `scope: { prop: '=' }` when accessing inherited members. In AngularJS 1.4, we could use `scope: {}, bindToController: { prop: '=' }` and move our bindings to the `bindToController` property to be more explicit in saying "I want to bind these to a Controller". This is just syntax sugar, and obviously AngularJS 1.3 doesn't support an Object as the value of `bindToController`, so this needed to change.
 
 Underneath it's identical, and it's also under a wrapper as we use `bindings` inside the `component()` method, so it doesn't really matter how we do the underlying detection and bindings.
 
@@ -179,4 +179,4 @@ The first code snippet says: "If isolate scope is set to `false`, then set `scop
 
 The second (my change) code snippet says: "If isolate scope is set to `false`, then set `scope` to `true` to inherit scope and prevent isolate scope. Otherwise assign my `bindings` property value. Set `bindToController` to the result of `options.bindings` cast to Boolean, using `!!` casting".
 
-Grab the code on [GitHub](https://github.com/toddmotto/angular-component) and start writing Angular 2 style components now. Enjoy!
+Grab the code on [GitHub](https://github.com/toddmotto/angular-component) and start writing Angular-style components now. Enjoy!

--- a/_posts/2016-02-05-one-way-data-binding-in-angular-1-5.md
+++ b/_posts/2016-02-05-one-way-data-binding-in-angular-1-5.md
@@ -7,7 +7,7 @@ tags:
 - Angular 2
 ---
 
-Angular is known for its powerful two-way data-binding, but with the new release of Angular 1.5, we've got one-way data binding (one-directional) binding capabilities inside our Components and Directives. Woohoo! Let's explore to see what it does, and doesn't, give us to develop with.
+Angular is known for its powerful two-way data-binding, but with the new release of AngularJS 1.5, we've got one-way data binding (one-directional) binding capabilities inside our Components and Directives. Woohoo! Let's explore to see what it does, and doesn't, give us to develop with.
 
 ### First impressions
 

--- a/_posts/2016-02-08-stateless-angular-components.md
+++ b/_posts/2016-02-08-stateless-angular-components.md
@@ -7,7 +7,7 @@ tags:
 - Angular
 ---
 
-There were a tonne of interesting changes happening in the `beta` and release candidate phases of Angular 1.5, one of them was the introduction of the [Component method](/exploring-the-angular-1-5-component-method), which saw [one-way bindings](/one-way-data-binding-in-angular-1-5) also introduced. We've also got the power to create stateless components.
+There were a tonne of interesting changes happening in the `beta` and release candidate phases of AngularJS 1.5, one of them was the introduction of the [Component method](/exploring-the-angular-1-5-component-method), which saw [one-way bindings](/one-way-data-binding-in-angular-1-5) also introduced. We've also got the power to create stateless components.
 
 ### What is a stateless component?
 
@@ -41,7 +41,7 @@ angular
   .component('nameComponent', NameComponent);
 {% endhighlight %}
 
-Let's add some data to another Controller and actually render this awesome component. 
+Let's add some data to another Controller and actually render this awesome component.
 
 _Please note: this example is using version `1.5.0-rc.0`_
 
@@ -77,13 +77,13 @@ And now it renders:
 
 <iframe width="100%" height="300" src="//jsfiddle.net/toddmotto/0oarywLe/embedded/result,js,html" allowfullscreen="allowfullscreen" frameborder="0"></iframe>
 
-Okay, well that's extremely annoying, I need to bind a `controller` and declare the `controllerAs` property to get things to render. 
+Okay, well that's extremely annoying, I need to bind a `controller` and declare the `controllerAs` property to get things to render.
 
 So we ended up adding these empty Controllers to make things "work", which isn't pretty.
 
 ### 1.5 stable saves the day
 
-The ability to not specify a Controller is available in the stable Angular 1.5 release! This means we can do exactly this _without_ a Controller:
+The ability to not specify a Controller is available in the stable AngularJS 1.5 release! This means we can do exactly this _without_ a Controller:
 
 {% highlight javascript %}
 // usage: <name-component></name-component>
@@ -113,7 +113,7 @@ Voila:
 
 <iframe width="100%" height="300" src="//jsfiddle.net/toddmotto/t242uxna/embedded/result,js,html" allowfullscreen="allowfullscreen" frameborder="0"></iframe>
 
-Components can now just act as stateless templates, and that's awesome and lightweight. 
+Components can now just act as stateless templates, and that's awesome and lightweight.
 
 ### Caveats
 

--- a/_posts/2016-02-11-on-init-require-object-syntax-angular-component.md
+++ b/_posts/2016-02-11-on-init-require-object-syntax-angular-component.md
@@ -5,7 +5,7 @@ title: $onInit and new "require" Object syntax in Angular components
 path: 2016-02-11-on-init-require-object-syntax-angular-component.md
 ---
 
-The `component()` helper method shipped with so many great features to take us even closer towards Angular 2 syntax and integration. Let's explore the `$onInit` method and the new `require` property's syntax that makes the `component()` method much more powerful. If you've not checked out the `component()` method just yet, check [my write-up on it here](/exploring-the-angular-1-5-component-method).
+The `component()` helper method shipped with so many great features to take us even closer towards Angular (v2+) syntax and integration. Let's explore the `$onInit` method and the new `require` property's syntax that makes the `component()` method much more powerful. If you've not checked out the `component()` method just yet, check [my write-up on it here](/exploring-the-angular-1-5-component-method).
 
 ### $onInit
 
@@ -42,7 +42,7 @@ And a live example:
 
 <iframe width="100%" height="300" src="//jsfiddle.net/toddmotto/f1y8u4yj/embedded/result,js,html" allowfullscreen="allowfullscreen" frameborder="0"></iframe>
 
-Angular 2 has the `ngOnInit` method, a great lifecycle callback that will help us transition from Angular 1.x. `ngOnInit` is called right after the directive's data-bound properties have been checked for the first time, and before any of its children have been checked. It is invoked only once when the directive is instantiated - much like in this Angular 1.x implementation.
+Angular has the `ngOnInit` method, a great lifecycle callback that will help us transition from AngularJS 1.x. `ngOnInit` is called right after the directive's data-bound properties have been checked for the first time, and before any of its children have been checked. It is invoked only once when the directive is instantiated - much like in this AngularJS 1.x implementation.
 
 ### Using "require" as an Object
 
@@ -110,7 +110,7 @@ angular
   .component('childComponent', {
     require: {},
     controller: function () {
-      
+
     },
     template: `
       <div>

--- a/_posts/2016-02-28-joining-telerik-as-developer-advocate.md
+++ b/_posts/2016-02-28-joining-telerik-as-developer-advocate.md
@@ -11,6 +11,6 @@ For me, this has been an absolute dream job role to aim for ever since I can rem
 
 I'll be working with the other fantastic Developer Relations team members (that I was so lucky to meet in the Developer Summit over in Austin, just fantastic). After just a day of working with the team, I knew I'd made the right job decision, and most importantly at the right company.
 
-There's a lot of things I'm going to be doing this year to help bring Telerik's vision and products (namely Kendo 2 and NativeScript) to JavaScript frameworks. I'll be working on both Angular 1 and 2 integration, React integrations and helping developers learn both the Angular and React frameworks, conference speaking, producing more content and mentoring other developers. I'm so excited for this next chapter in my career!
+There's a lot of things I'm going to be doing this year to help bring Telerik's vision and products (namely Kendo 2 and NativeScript) to JavaScript frameworks. I'll be working on both AngularJS (1.x) and Angular (v2+) integration, React integrations and helping developers learn both the Angular and React frameworks, conference speaking, producing more content and mentoring other developers. I'm so excited for this next chapter in my career!
 
 Lastly, a huge thanks to everyone who has inspired me to become a better person, engineer, speaker and finally get outside my comfort zone to push my skills further - to take a leap of faith in life.

--- a/_posts/2016-03-05-bootstrap-angular-2-hello-world.md
+++ b/_posts/2016-03-05-bootstrap-angular-2-hello-world.md
@@ -7,14 +7,14 @@ tags:
 - Angular 2
 ---
 
-In this series of four Angular posts, we'll explore how to bootstrap an Angular app, create a component, pass data into a component and pass new data out of a component using events. 
+In this series of four Angular (v2+) posts, we'll explore how to bootstrap an Angular app, create a component, pass data into a component and pass new data out of a component using events.
 
 ### Series
 
-1. Bootstrapping your first Angular 2+ app
-2. [Creating your first Angular 2+ component](/creating-your-first-angular-2-component)
-3. [Passing data into Angular 2+ components with @Input](/passing-data-angular-2-components-input)
-4. [Component events with EventEmitter and @Output in Angular 2+](/component-events-event-emitter-output-angular-2)
+1. Bootstrapping your first Angular app
+2. [Creating your first Angular component](/creating-your-first-angular-2-component)
+3. [Passing data into Angular components with @Input](/passing-data-angular-2-components-input)
+4. [Component events with EventEmitter and @Output in Angular](/component-events-event-emitter-output-angular-2)
 
 ### Introduction
 

--- a/_posts/2016-03-06-emulated-native-shadow-dom-angular-2-view-encapsulation.md
+++ b/_posts/2016-03-06-emulated-native-shadow-dom-angular-2-view-encapsulation.md
@@ -9,15 +9,15 @@ tags:
 
 Shadow DOM has long been a talking point on the web, and the [Polymer project](//www.polymer-project.org/1.0) pushes the proof of concept quite nicely, however, adoption of "raw" Web Components (Shadow DOM is part of the spec) is low. Instead, frameworks have provided "better" ways to achieve results and develop applications.
 
-Angular 2 isn't ignorant to Web Components at all, and provides us the powerful ability to use native Shadow DOM when we choose. We also have the choice to emulate Shadow DOM through Angular 2, achieving somewhat encapsulated Components and styling. If you need an overview on Web Components and Shadow DOM, I'd [check out my article](/web-components-concepts-shadow-dom-imports-templates-custom-elements/) on it!
+Angular (v2+) isn't ignorant to Web Components at all, and provides us the powerful ability to use native Shadow DOM when we choose. We also have the choice to emulate Shadow DOM through Angular, achieving somewhat encapsulated Components and styling. If you need an overview on Web Components and Shadow DOM, I'd [check out my article](/web-components-concepts-shadow-dom-imports-templates-custom-elements/) on it!
 
 ### Problem we're solving
 
-The problem in the way we create web applications lies in the "global-like" architecture that HTML, CSS and JavaScript gives us, for instance an `.active {}` class will be painted to all DOM elements containing the class name `active`, such as `<div class="active"></div>`. The same applies to JavaScript, the code we write is lexically scoped, and usually we create forms of global Objects (such as `window.angular` in Angular 1.x to hook into Angular from any JavaScript scope).
+The problem in the way we create web applications lies in the "global-like" architecture that HTML, CSS and JavaScript gives us, for instance an `.active {}` class will be painted to all DOM elements containing the class name `active`, such as `<div class="active"></div>`. The same applies to JavaScript, the code we write is lexically scoped, and usually we create forms of global Objects (such as `window.angular` in AngularJS 1.x to hook into Angular from any JavaScript scope).
 
 When it comes to Shadow DOM, the tables are turned, as Shadow DOM creates DOM inside DOM, combining multiple DOM trees into a single hierarchy. These chunks of isolated DOM act as a "shield" around all these global entities such as CSS and JavaScript logic and are locally scoped to one another.
 
-Let's see how Shadow DOM is applied in Angular 2 using the `styles` property to add styles to Components, and the `encapsulation` property to manage how we want Angular 2 to contain our Components.
+Let's see how Shadow DOM is applied in Angular using the `styles` property to add styles to Components, and the `encapsulation` property to manage how we want Angular to contain our Components.
 
 ### Style property
 
@@ -75,7 +75,7 @@ Next, let's create some global HTML and CSS and add it to the Plunker. This will
 </html>
 {% endhighlight %}
 
-As you can see from adding this, our `AppComponent` with the `<input>` inside also inherits the `green` global styling. This is because of how Angular 2's default `ViewEncapsulation` mode.
+As you can see from adding this, our `AppComponent` with the `<input>` inside also inherits the `green` global styling. This is because of how Angular's default `ViewEncapsulation` mode.
 
 <iframe src="//embed.plnkr.co/Td3OCsqtpxYNrgHCafL5" frameborder="0" border="0" cellspacing="0" cellpadding="0" width="100%" height="250"></iframe>
 
@@ -83,7 +83,7 @@ Let's dive into each `ViewEncapsulation` mode to see what each of them gives us.
 
 ### ViewEncapsulation.Emulated
 
-Using the `Emulated` property gives us emulated Shadow DOM/encapsulation which is the _default_ behaviour for Angular 2 Components. Even though it's a default, we'll add it to a live example anyway to see what happens. Let's import `ViewEncapsulation` from the Angular 2 core and set the `encapsulation` property:
+Using the `Emulated` property gives us emulated Shadow DOM/encapsulation which is the _default_ behaviour for Angular Components. Even though it's a default, we'll add it to a live example anyway to see what happens. Let's import `ViewEncapsulation` from the Angular core and set the `encapsulation` property:
 
 {% highlight javascript %}
 import { Component, ViewEncapsulation } from '@angular/core';
@@ -248,7 +248,7 @@ It means that CSS we write globally will inherit, however styles defined using t
 
 ### Web Component footsteps
 
-Angular 2 moves even closer to the Web Components spec through the use of the `:host {}` selector, both with `Native` or `Emulated` styles. A quick example of using the `:host {}` selector:
+Angular moves even closer to the Web Components spec through the use of the `:host {}` selector, both with `Native` or `Emulated` styles. A quick example of using the `:host {}` selector:
 
 {% highlight javascript %}
 import { Component, ViewEncapsulation } from '@angular/core';
@@ -283,4 +283,4 @@ Notice how the red background now spans the full element using the `:host` selec
 
 ##### What does this mean?
 
-It means we can use the `:host` selector to style the declared element, in this case the `:host` is the same element as Angular 2 annotated above in the `ViewEncapsulation.Emulated` overview as `<my-app _nghost-cmy-1="">`. Note the `_nghost-*` attribute, in `Native` mode this attribute is removed and we use native Shadow DOM, in which case just `<my-app>` refers to the host element and therefore is targeted by the `:host {}` selector.
+It means we can use the `:host` selector to style the declared element, in this case the `:host` is the same element as Angular annotated above in the `ViewEncapsulation.Emulated` overview as `<my-app _nghost-cmy-1="">`. Note the `_nghost-*` attribute, in `Native` mode this attribute is removed and we use native Shadow DOM, in which case just `<my-app>` refers to the host element and therefore is targeted by the `:host {}` selector.

--- a/_posts/2016-03-17-creating-an-angular-2-component.md
+++ b/_posts/2016-03-17-creating-an-angular-2-component.md
@@ -7,14 +7,14 @@ tags:
 - Angular 2
 ---
 
-This is a beginner level tutorial to ease you into Angular, although there are many resources online to creating components, these articles exist as part of a series. This article will guide you through creating your first Angular component.
+This is a beginner level tutorial to ease you into Angular (v2+), although there are many resources online to creating components, these articles exist as part of a series. This article will guide you through creating your first Angular component.
 
 ### Series
 
-1. [Bootstrapping your first Angular 2+ app](/bootstrap-angular-2-hello-world)
-2. Creating your first Angular 2+ component
-3. [Passing data into Angular 2+ components with @Input](/passing-data-angular-2-components-input)
-4. [Component events with EventEmitter and @Output in Angular 2+](/component-events-event-emitter-output-angular-2)
+1. [Bootstrapping your first Angular app](/bootstrap-angular-2-hello-world)
+2. Creating your first Angular component
+3. [Passing data into Angular components with @Input](/passing-data-angular-2-components-input)
+4. [Component events with EventEmitter and @Output in Angular](/component-events-event-emitter-output-angular-2)
 
 ### Introduction
 

--- a/_posts/2016-03-18-passing-data-angular-2-components-input.md
+++ b/_posts/2016-03-18-passing-data-angular-2-components-input.md
@@ -15,18 +15,18 @@ This custom input binding is created via the `@Input()` decorator! Let's explore
 
 ### Series
 
-1. [Bootstrapping your first Angular 2+ app](/bootstrap-angular-2-hello-world)
-2. [Creating your first Angular 2+ component](/creating-your-first-angular-2-component)
-3. Passing data into Angular 2+ components with @Input
-4. [Component events with EventEmitter and @Output in Angular 2+](/component-events-event-emitter-output-angular-2)
+1. [Bootstrapping your first Angular app](/bootstrap-angular-2-hello-world)
+2. [Creating your first Angular component](/creating-your-first-angular-2-component)
+3. Passing data into Angular components with @Input
+4. [Component events with EventEmitter and @Output in Angular](/component-events-event-emitter-output-angular-2)
 
 ### Introduction
 
 This tutorial will cover passing data into a component, and we'll be using the Counter component we built in the previous article. If you've not dived in and learned how to create a component in Angular, [check that out here](/creating-your-first-angular-2-component), as we'll be using the same source code to continue building.
 
-### Angular 1.x
+### AngularJS
 
-For those coming from an Angular 1.x background, this concept looks a little like this with the [.component method](/exploring-the-angular-1-5-component-method/):
+For those coming from an AngularJS background, this concept looks a little like this with the [.component method](/exploring-the-angular-1-5-component-method/):
 
 ```js
 const counter = {
@@ -123,15 +123,15 @@ import { Component } from '@angular/core';
 export class CounterComponent {
 
   count: number = 0;
-  
+
   increment() {
     this.count++;
   }
-  
+
   decrement() {
     this.count--;
   }
-  
+
 }
 ```
 
@@ -147,19 +147,19 @@ export class CounterComponent {
 
   @Input()
   count: number = 0;
-  
+
   increment() {
     this.count++;
   }
-  
+
   decrement() {
     this.count--;
   }
-  
+
 }
 ```
 
-This decorator tells Angular to treat `count` as an input binding, much like the Angular 1.x `'<'` syntax if you're coming from an Angular 1.x background. This syntax is easier and shorter, as we only manage our bindings in a single place, rather than a `bindings` object like we saw at the beginning of this tutorial.
+This decorator tells Angular to treat `count` as an input binding, much like the AngularJS 1.x `'<'` syntax if you're coming from an AngularJS 1.x background. This syntax is easier and shorter, as we only manage our bindings in a single place, rather than a `bindings` object like we saw at the beginning of this tutorial.
 
 > Tip: you can see `number = 0`, we're keeping this as an optional default value, so if no input binding is supplied, the component will be initialised with a count of `0`.
 
@@ -191,9 +191,9 @@ export class CounterComponent {
 
   @Input()
   count: number = 0;
-  
+
   // ...
-  
+
 }
 ```
 
@@ -205,9 +205,9 @@ export class CounterComponent {
 
   @Input('init')
   count: number = 0;
-  
+
   // ...
-  
+
 }
 ```
 

--- a/_posts/2016-03-19-component-events-event-emitter-output-angular-2.md
+++ b/_posts/2016-03-19-component-events-event-emitter-output-angular-2.md
@@ -7,16 +7,16 @@ tags:
 - Angular 2
 ---
 
-Angular components have a far better way of notifying parent components that something has changed, via events. There's no longer two-way data binding in Angular in the same way we knew it in Angular 1.x, it's designed around a uni-directional data flow system that adopts a much more reasonable approach to application development.
+Angular components have a far better way of notifying parent components that something has changed, via events. There's no longer two-way data binding in Angular in the same way we knew it in AngularJS, it's designed around a uni-directional data flow system that adopts a much more reasonable approach to application development.
 
 Let's finalise the basics of parent-child and child-parent communication by introducing `EventEmitter` and `@Output`.
 
 ### Series
 
-1. [Bootstrapping your first Angular 2+ app](/bootstrap-angular-2-hello-world)
-2. [Creating your first Angular 2+ component](/creating-your-first-angular-2-component)
-3. [Passing data into Angular 2+ components with @Input](/passing-data-angular-2-components-input)
-4. Component events with EventEmitter and @Output in Angular 2+
+1. [Bootstrapping your first Angular app](/bootstrap-angular-2-hello-world)
+2. [Creating your first Angular component](/creating-your-first-angular-2-component)
+3. [Passing data into Angular components with @Input](/passing-data-angular-2-components-input)
+4. Component events with EventEmitter and @Output in Angular
 
 ### Introduction
 
@@ -24,9 +24,9 @@ This tutorial will cover stateless component events using the `EventEmitter` API
 
 This post follows from the previous article on [passing data in Angular components with @Input](/passing-data-angular-2-components-input).
 
-### Angular 1.x
+### AngularJS
 
-For those coming from an Angular 1.x background, this concept could look a little like this with the `.component()` API and callback binding using `'&'`:
+For those coming from an AngularJS background, this concept could look a little like this with the `.component()` API and callback binding using `'&'`:
 
 ```js
 const counter = {
@@ -102,7 +102,7 @@ import { Component } from '@angular/core';
 export class AppComponent {
   myCount: number = 10;
   countChange(event) {
-    
+
   }
 }
 ```
@@ -125,15 +125,15 @@ import { Component, Input, Output } from '@angular/core';
 
 @Component({...})
 export class CounterComponent {
-  
+
   @Input()
   count: number = 0;
-  
+
   @Output()
   change;
 
   // ...
-  
+
 }
 ```
 
@@ -148,14 +148,14 @@ import { Component, Input, Output, EventEmitter } from '@angular/core';
 
 @Component({...})
 export class CounterComponent {
-  
+
   // ...
-  
+
   @Output()
   change = new EventEmitter();
 
   // ...
-  
+
 }
 ```
 
@@ -166,14 +166,14 @@ import { Component, Input, Output, EventEmitter } from '@angular/core';
 
 @Component({...})
 export class CounterComponent {
-  
+
   // ...
-  
+
   @Output()
   change: EventEmitter<number> = new EventEmitter<number>();
 
   // ...
-  
+
 }
 ```
 
@@ -181,28 +181,28 @@ export class CounterComponent {
 
 So what's happening here? We've created a `change` property, and bound a new instance of `EventEmitter` to it - what next?
 
-Much like the Angular 1.x example I showed at the beginning, we can simply call our `this.change` method - however because it references an instance of `EventEmitter`, we have to call `.emit()` to emit an event to the parent:
+Much like the AngularJS example I showed at the beginning, we can simply call our `this.change` method - however because it references an instance of `EventEmitter`, we have to call `.emit()` to emit an event to the parent:
 
 ```js
 @Component({...})
 export class CounterComponent {
-  
+
   @Input()
   count: number = 0;
-  
+
   @Output()
   change: EventEmitter<number> = new EventEmitter<number>();
-  
+
   increment() {
     this.count++;
     this.change.emit(this.count);
   }
-  
+
   decrement() {
     this.count--;
     this.change.emit(this.count);
   }
-  
+
 }
 ```
 
@@ -271,22 +271,22 @@ We can hook up our custom property name, whilst preserving the internal `@Output
 ```js
 @Component({...})
 export class CounterComponent {
-  
+
   // ...
-  
+
   @Output('update')
   change: EventEmitter<number> = new EventEmitter<number>();
-  
+
   increment() {
     this.count++;
     this.change.emit(this.count);
   }
-  
+
   decrement() {
     this.count--;
     this.change.emit(this.count);
   }
-  
+
 }
 ```
 
@@ -294,7 +294,7 @@ Essentially, we're just telling Angular here to lookup `update` as the property 
 
 ### Plunker
 
-Everything we've done here is readily available in a Plunker for you to have a look through. 
+Everything we've done here is readily available in a Plunker for you to have a look through.
 
 You can try the version _without_ the `this.myCount` callback assignment here to see how the local state change doesn't update the parent:
 

--- a/_posts/2016-04-19-angular-2-authentication.md
+++ b/_posts/2016-04-19-angular-2-authentication.md
@@ -7,23 +7,23 @@ tags:
 - Angular 2
 ---
 
-If you've needed to add authentication to an Angular 1.x app, you'll have likely have had some fun and perhaps been lost at where to start. Traditional methods of session and cookie-based auth are challenging for full-on single page apps regardless of the framework or strategy you choose, so I've usually used [JSON Web Tokens JWT](https://jwt.io/introduction) for stateless authentication instead. Even when using JWTs though, there's still a lot that needs to be kept in check. Things like hiding and showing various parts of the UI based on the user's authentication state, attaching the JWT as an `Authorization` header in HTTP requests, and redirecting to the login route when a request gets rejected as being invalid.
+If you've needed to add authentication to an AngularJS (1.x) app, you'll have likely have had some fun and perhaps been lost at where to start. Traditional methods of session and cookie-based auth are challenging for full-on single page apps regardless of the framework or strategy you choose, so I've usually used [JSON Web Tokens JWT](https://jwt.io/introduction) for stateless authentication instead. Even when using JWTs though, there's still a lot that needs to be kept in check. Things like hiding and showing various parts of the UI based on the user's authentication state, attaching the JWT as an `Authorization` header in HTTP requests, and redirecting to the login route when a request gets rejected as being invalid.
 
-When it comes to adding authentication to an Angular 2 app, we still need to think about these things, but the approach is a little different. To start, we no longer have the concept of HTTP interceptors in Angular 2, like we did in Angular 1.x, which means we need some other way of binding the user's JWT to requests.
+When it comes to adding authentication to an Angular (v2+) app, we still need to think about these things, but the approach is a little different. To start, we no longer have the concept of HTTP interceptors in Angular, like we did in AngularJS, which means we need some other way of binding the user's JWT to requests.
 
 Implementing authentication on the front end is only half the battle though - we also need to create some backend code that checks the user's credentials, signs tokens for them, and checks whether the token is valid when requests are made to our API endpoints. Which is a lot of work! It's also prone to error and is something that's really important to get right, obviously!
 
-So, in this post we're going to demonstrate how to handle authentication using Angular 2, [Node.js](https://nodejs.org) and [Auth0](https://auth0.com/?utm_source=toddmotto&utm_medium=gp&utm_campaign=angular2_auth) which I've used with working on Angular 1.x, so this is great to be able to dive into Angular 2 with what I'm used to. Auth0 lets us forget about most of the backend logic altogether (I'm no backend programmer) and integrates nicely with Node, so all we really need to do is make sure that our Angular app is set up to save and send JWTs. Let's get started!
+So, in this post we're going to demonstrate how to handle authentication using Angular, [Node.js](https://nodejs.org) and [Auth0](https://auth0.com/?utm_source=toddmotto&utm_medium=gp&utm_campaign=angular2_auth) which I've used with working on AngularJS, so this is great to be able to dive into Angular with what I'm used to. Auth0 lets us forget about most of the backend logic altogether (I'm no backend programmer) and integrates nicely with Node, so all we really need to do is make sure that our Angular app is set up to save and send JWTs. Let's get started!
 
 ### Prerequisites
 
-If you've not dived much into Angular 2, I've some articles that are probably a good place to start first, [bootstrapping your first app](https://toddmotto.com/bootstrap-angular-2-hello-world) and [creating your first Component](https://toddmotto.com/creating-your-first-angular-2-component).
+If you've not dived much into Angular, I've some articles that are probably a good place to start first, [bootstrapping your first app](https://toddmotto.com/bootstrap-angular-2-hello-world) and [creating your first Component](https://toddmotto.com/creating-your-first-angular-2-component).
 
 ### Setup
 
-First, you'll need to make sure you have [Angular 2](//angular.io) and [Node.js](https://nodejs.org) available, as well as a free [Auth0](https://auth0.com/?utm_source=toddmotto&utm_medium=gp&utm_campaign=angular2_auth) account (it's free up to 7,000 active users which is plenty, though if you're running an open source project then Auth0 is free if you drop in their logo, perks).
+First, you'll need to make sure you have [Angular](//angular.io) and [Node.js](https://nodejs.org) available, as well as a free [Auth0](https://auth0.com/?utm_source=toddmotto&utm_medium=gp&utm_campaign=angular2_auth) account (it's free up to 7,000 active users which is plenty, though if you're running an open source project then Auth0 is free if you drop in their logo, perks).
 
-Before we can dive into Angular 2 + Node, we need to configure some fake users in Auth0, so jump [here](https://auth0.com/signup/?utm_source=toddmotto&utm_medium=gp&utm_campaign=angular2_auth) if you're following along and create some users in the [management dashboard](https://manage.auth0.com). We get a default app when we register, and this app comes with a domain and client ID which we'll need later.
+Before we can dive into Angular + Node, we need to configure some fake users in Auth0, so jump [here](https://auth0.com/signup/?utm_source=toddmotto&utm_medium=gp&utm_campaign=angular2_auth) if you're following along and create some users in the [management dashboard](https://manage.auth0.com). We get a default app when we register, and this app comes with a domain and client ID which we'll need later.
 
 ### Next steps
 
@@ -44,7 +44,7 @@ Now we simply drop in the lock script into our `index.html` file somewhere in th
 
 ### Angular Authentication Service
 
-One question that frequents when implementing auth in Angular apps is "where does the logic go?". Sometimes our apps will only have one location where the login is managed and other times there will be multiple locations. So we're going to just be creating one Service to keep things simple. Now using Angular 2, we're going to be creating an `AuthService` and mark it as `@Injectable()` so we can dependency inject it wherever we want:
+One question that frequents when implementing auth in Angular apps is "where does the logic go?". Sometimes our apps will only have one location where the login is managed and other times there will be multiple locations. So we're going to just be creating one Service to keep things simple. Now using Angular, we're going to be creating an `AuthService` and mark it as `@Injectable()` so we can dependency inject it wherever we want:
 
 {% highlight javascript %}
 // services/auth.service.ts
@@ -164,7 +164,7 @@ export class UserListComponent implements OnInit {
 }
 {% endhighlight %}
 
-When we use `AuthHttp` instead of the regular `Http` module shipped with Angular 2, the JWT in `localStorage` gets attached as an `Authorization` header automatically. We could of course write some logic to create `Headers` and then attach them to each regular `Http` request manually, but `angular2-jwt` does this for us.
+When we use `AuthHttp` instead of the regular `Http` module shipped with Angular, the JWT in `localStorage` gets attached as an `Authorization` header automatically. We could of course write some logic to create `Headers` and then attach them to each regular `Http` request manually, but `angular2-jwt` does this for us.
 
 ### Middleware on the Server
 
@@ -225,7 +225,7 @@ loggedIn(): boolean {
 // ...
 {% endhighlight %}
 
-This will return `true` or `false` depending on whether the JWT in `localStorage` is expired or not. Now let's apply it to our Angular 2 template:
+This will return `true` or `false` depending on whether the JWT in `localStorage` is expired or not. Now let's apply it to our Angular template:
 
 {% highlight javascript %}
 // components/toolbar.component.ts
@@ -253,4 +253,4 @@ We've already composed a `logout` method on the `AuthService`, and all that it r
 
 ### Wrapping up
 
-Hopefully you've had some decent insight into Angular 2 authentication with JSON Web Tokens, Auth0 and Node. It's been a pretty simple journey using Auth0 for all of this and it was awesome implementing it inside Angular 2!
+Hopefully you've had some decent insight into Angular authentication with JSON Web Tokens, Auth0 and Node. It's been a pretty simple journey using Auth0 for all of this and it was awesome implementing it inside Angular!

--- a/_posts/2016-06-03-lifecycle-hooks.md
+++ b/_posts/2016-06-03-lifecycle-hooks.md
@@ -7,7 +7,7 @@ tags:
 - Angular
 ---
 
-Lifecycle hooks are simply functions that get called at specific points of a component's life in our Angular apps. They landed in Angular 1.5 and are to be used alongside the [.component() method](/exploring-the-angular-1-5-component-method/), and have slowly evolved over the last few versions to include some more powerful (and Angular 2 inspired) hooks. Let's explore in-depth how we can actually use them, the roles they play and why you should use them - this is especially important with a component architecture based app.
+Lifecycle hooks are simply functions that get called at specific points of a component's life in our Angular apps. They landed in AngularJS 1.5 and are to be used alongside the [.component() method](/exploring-the-angular-1-5-component-method/), and have slowly evolved over the last few versions to include some more powerful (and Angular v2+ inspired) hooks. Let's explore in-depth how we can actually use them, the roles they play and why you should use them - this is especially important with a component architecture based app.
 
 I've spent some time [polyfilling the `.component()` method](https://github.com/toddmotto/angular-component) and all the lifecycle hooks back to Angular v1.3.0+, so it's been a massive insight as to how we actually use these hooks and their roles in components. Let's dive in.
 
@@ -135,7 +135,7 @@ var myComponent = {
 };
 {% endhighlight %}
 
-Notice, that with Angular 1.5.6 (see the [CHANGELOG](https://github.com/angular/angular.js/blob/master/CHANGELOG.md#156-arrow-stringification-2016-05-27)) the require now supports to omit the required controller name if it is the same used to bind the requiring controller. This feature does not introduce breaking changes and can be used as follows:
+Notice, that with AngularJS 1.5.6 (see the [CHANGELOG](https://github.com/angular/angular.js/blob/master/CHANGELOG.md#156-arrow-stringification-2016-05-27)) the require now supports to omit the required controller name if it is the same used to bind the requiring controller. This feature does not introduce breaking changes and can be used as follows:
 
 {% highlight javascript %}
 var myComponent = {
@@ -504,7 +504,7 @@ So why does it exist? You might need to use _some_ DOM manipulation or custom ev
 
 ### $onChanges
 
-This is a big one (also the most important), and aligns with how we use component architecture and one-way dataflow with Angular 1.5.x. The golden rule to remember is, `$onChanges` is called in the _local_ component controller from changes that occurred in the _parent_ controller. Changes that occur from the parent which are inputted into a component using `bindings: {}` is the secret sauce here.
+This is a big one (also the most important), and aligns with how we use component architecture and one-way dataflow with AngularJS 1.5.x. The golden rule to remember is, `$onChanges` is called in the _local_ component controller from changes that occurred in the _parent_ controller. Changes that occur from the parent which are inputted into a component using `bindings: {}` is the secret sauce here.
 
 ##### What calls $onChanges?
 
@@ -796,7 +796,7 @@ var childComponent = {
 };
 {% endhighlight %}
 
-Okay, bear with me, we're in the final phase. This is where things get... interesting. Instead of just passig back `this.user` into the function, we're going to fake an `$event` Object, which complies with how Angular 2 does this (using `EventEmitter`), and also provides global consistency between your templates to fetch data back through the `$ctrl.updateUser($event);` call we delegate down into the child component. The `$event` argument is a real thing in Angular, you can use it with ng-submit and so on. If you remember this function:
+Okay, bear with me, we're in the final phase. This is where things get... interesting. Instead of just passing back `this.user` into the function, we're going to fake an `$event` Object, which complies with how Angular (v2+) does this (using `EventEmitter`), and also provides global consistency between your templates to fetch data back through the `$ctrl.updateUser($event);` call we delegate down into the child component. The `$event` argument is a real thing in Angular, you can use it with ng-submit and so on. If you remember this function:
 
 {% highlight javascript %}
 this.updateUser = function (event) {
@@ -832,7 +832,7 @@ There's also a free video available from my AngularJS master course on `$onChang
 
 ##### Is two-way binding through "=" syntax dead?
 
-Yes. One-way binding is established as the best way to approach data flow, React, Angular 2 and others all use it. Now it's Angular 1's turn, a little late to the party, but hey, this is insanely powerful and changes the way new Angular 1.x apps are created.
+Yes. One-way binding is established as the best way to approach data flow: React, Angular and others all use it. Now it's AngularJS's turn, a little late to the party, but hey, this is insanely powerful and changes the way new AngularJS apps are created.
 
 <img src="/img/posts/binding-dead.jpg" style="max-width: 100%;">
 
@@ -906,4 +906,4 @@ If you're using `$postLink` to set DOM event listeners or any non-native Angular
 
 ### Conclusion
 
-Angular 1.x app developer just changed forever with one-way dataflow, events and these lifecycle hooks. More posts on component architecture coming soon.
+AngularJS app developer just changed forever with one-way dataflow, events and these lifecycle hooks. More posts on component architecture coming soon.

--- a/_posts/2016-06-13-rewriting-angular-styleguide-angular-2.md
+++ b/_posts/2016-06-13-rewriting-angular-styleguide-angular-2.md
@@ -7,15 +7,15 @@ tags:
 - Angular 2
 ---
 
-As many of you know, I created an Angular 1.x styleguide [back in July 2014](https://github.com/toddmotto/angular-styleguide/commit/47a125d71c50a56515c7b4aadcd31247d74dc723), it's grown in popularity since inception, and has served many teams across the world to be a reference to code consistency. Angular has also changed, and many of the practices used back then aren't relevant today. As of now, the old styleguide is deprecated in favour of the new release.
+As many of you know, I created an AngularJS (1.x) styleguide [back in July 2014](https://github.com/toddmotto/angular-styleguide/commit/47a125d71c50a56515c7b4aadcd31247d74dc723), it's grown in popularity since inception, and has served many teams across the world to be a reference to code consistency. Angular has also changed, and many of the practices used back then aren't relevant today. As of now, the old styleguide is deprecated in favour of the new release.
 
 Read the [new Styleguide on GitHub](https://github.com/toddmotto/angular-styleguide) dedicated to ES2015, component architecture and one-way dataflow practices.
 
 ## What are the goals of the new styleguide?
 
-First off, the styleguide has been overhauled with a new approach - to _not_ compare "good" versus "bad" things to do with Angular. It also doesn't focus on wishy-washy type stuff that we are old enough to decide for ourselves, it's straight to the point and more of an architectural guide with code examples for all the latest standards. Instead, the styleguide focuses purely on what's good practice, and how we can utilise them with ES2015. Most importantly, it focuses on the design patterns associated with Angular (state management suggestions, stateless, stateful and routed components and component routing). It's focusing on the right ingredients, and how to prepare your apps for a new Angular 1.x standard, as well as integrating patterns for upgrading to Angular 2.
+First off, the styleguide has been overhauled with a new approach - to _not_ compare "good" versus "bad" things to do with Angular. It also doesn't focus on wishy-washy type stuff that we are old enough to decide for ourselves, it's straight to the point and more of an architectural guide with code examples for all the latest standards. Instead, the styleguide focuses purely on what's good practice, and how we can utilise them with ES2015. Most importantly, it focuses on the design patterns associated with Angular (state management suggestions, stateless, stateful and routed components and component routing). It's focusing on the right ingredients, and how to prepare your apps for a new AngularJS standard, as well as integrating patterns for upgrading to Angular 2.
 
-Angular 1.x has changed vastly since the original styleguide was created, and many of the recommendations there and best practices have been implemented via Angular updates, and ES6/ES2015 has now become a defacto standard in new projects that allow us to move away from problems we faced. The new styleguide focuses on using ES2015, offering recommendations on tooling to use it today. This means a few things for us, so let's dive in to explore the reasons why this styleguide ignores most of the original styleguide content and why I believe it's crucial for us now.
+AngularJS has changed vastly since the original styleguide was created, and many of the recommendations there and best practices have been implemented via Angular updates, and ES6/ES2015 has now become a defacto standard in new projects that allow us to move away from problems we faced. The new styleguide focuses on using ES2015, offering recommendations on tooling to use it today. This means a few things for us, so let's dive in to explore the reasons why this styleguide ignores most of the original styleguide content and why I believe it's crucial for us now.
 
 Note: all statements below are integrated into the guide, you'll find answers to "how is that done?" there.
 
@@ -43,7 +43,7 @@ Note: all statements below are integrated into the guide, you'll find answers to
 * We can use ES2015 `Class`
   * This allows us to disregard `var ctrl = this;` patterns
   * This also mitigates the desire to use `$scope`
-  * This allows us to shift a lot of our code to Angular 2 style
+  * This allows us to shift a lot of our code to Angular (v2+) style
 * We no longer need to think about `$scope`
   * You don't need `$scope` for handling your view logic, however for `$watch` and events you still need it
 * We no longer need to think about `controllerAs`
@@ -78,9 +78,9 @@ Note: all statements below are integrated into the guide, you'll find answers to
 * We don't need a styleguide on how to write an ES2015 Class and export it
   * `$inject` properties are demonstrated in the guide
 
-### Angular 2
+### Angular (v2+)
 
-All of the best practices for using Angular 2, and planning your application's migration to Angular 2 live inside the styleguide.
+All of the best practices for using Angular, and planning your application's migration to Angular live inside the styleguide.
 
 ### Resources and tooling
 
@@ -88,7 +88,7 @@ The guide also has an initial resources section which points to articles that ex
 
 ### List of things I feel are deprecated
 
-These still exist in Angular 1.x, however I feel they should be treated as deprecated and advise against them.
+These still exist in AngularJS, however I feel they should be treated as deprecated and advise against them.
 
 * Two-way databinding through `{ foo: '=' }` syntax
 * `controllerAs` syntax
@@ -106,7 +106,7 @@ These still exist in Angular 1.x, however I feel they should be treated as depre
   * transclude
   * Why? Use `.component()` because that's the correct tool now
 * The `.factory()` method
-  * Use an ES2015 Class for a Service, like in Angular 2
+  * Use an ES2015 Class for a Service, like in Angular (v2+)
 * The `.controller()` method
   * Use `controller: fn` on components only
 * Using `template: '<my-component>'` with ui-router

--- a/_posts/2016-08-15-promises-angular-q.md
+++ b/_posts/2016-08-15-promises-angular-q.md
@@ -5,7 +5,7 @@ title: All about $q and Promises in Angular
 path: 2016-08-15-promises-angular-q.md
 ---
 
-You've seen `$q`, maybe used it but haven't uncovered some of the awesome features `$q` provides such as `$q.all()` and `$q.race()`. This article dives into ES2015 Promise API and how it maps across to `$q` for AngularJS. This post is all about `$q`... enjoy!
+You've seen `$q`, maybe used it, but haven't uncovered some of the awesome features `$q` provides, such as `$q.all()` and `$q.race()`. This article dives into ES2015 Promise API and how it maps across to `$q` for AngularJS. This post is all about `$q`... enjoy!
 
 ### Table of contents
 

--- a/_posts/2016-09-30-document-angular.markdown
+++ b/_posts/2016-09-30-document-angular.markdown
@@ -886,13 +886,13 @@ config.$inject = ["$locationProvider", "$stateProvider", "API_DATA", "GUIDE_DATA
 
 ### 9. Documenting a Module, Controller, Directive and Service
 
-In the interest of time, I will actually be documenting an existing Angular 1.5 app.
+In the interest of time, I will actually be documenting an existing AngularJS 1.5 app.
 
-I'm using Todd Motto's (the owner of this blog) [Angular 1.5 Component app][dfa622d3] as a living example. If you haven't had the time to check it out, do so... it's the best example of a .component() based application using UI-Router 1.0 beta using routed components.
+I'm using Todd Motto's (the owner of this blog) [AngularJS 1.5 Component app][dfa622d3] as a living example. If you haven't had the time to check it out, do so... it's the best example of a .component() based application using UI-Router 1.0 beta using routed components.
 
 The examples from this guide are also available directly in the app, under `/docs`. So feel free to fork the app to see it in action, and learn about how you should be building Angular apps in 2016 at the same time!
 
-[dfa622d3]: https://github.com/toddmotto/angular-1-5-components-app "Angular 1.5 Component app"
+[dfa622d3]: https://github.com/toddmotto/angular-1-5-components-app "AngularJS 1.5 Component app"
 
 #### Documenting a Module
 

--- a/_posts/2016-10-12-stateful-stateless-components-missing-manual.md
+++ b/_posts/2016-10-12-stateful-stateless-components-missing-manual.md
@@ -22,7 +22,7 @@ The goals of this article are to define what stateful and stateless components a
   - <a href="#stateless-todoform-component">Stateless TodoForm component</a>
   - <a href="#stateless-todolist-component">Stateless TodoList component</a>
   - <a href="#final-code">Final code</a>
-- <a href="#angular-1x-version">Angular 1.x version?</a>
+- <a href="#angular-1x-version">AngularJS 1.x version?</a>
   - <a href="#final-code">Final code</a>
 - <a href="#further-reading">Further reading</a>
 
@@ -333,13 +333,13 @@ Altogether now:
 
 <iframe src="//embed.plnkr.co/ygSstbXkJf5vnGz6Fzdu" frameborder="0" border="0" cellspacing="0" cellpadding="0" width="100%" height="400"></iframe>
 
-### Angular 1.x version?
+### AngularJS 1.x version?
 
 Oh why not...
 
 #### Full 1.x implementation
 
-Here's the [full source code](https://jsfiddle.net/toddmotto/88g1gef4/) for the Angular 1.x version (obviously in a real app we'd use ES6 `import` and `export` statements etc):
+Here's the [full source code](https://jsfiddle.net/toddmotto/88g1gef4/) for the AngularJS 1.x version (obviously in a real app we'd use ES6 `import` and `export` statements etc):
 
 {% highlight javascript %}
 const todos = {

--- a/_posts/2016-10-18-angular-2-forms-template-driven.md
+++ b/_posts/2016-10-18-angular-2-forms-template-driven.md
@@ -7,7 +7,7 @@ tags:
 - Angular 2
 ---
 
-Angular 2 presents two different methods for creating forms, template-driven (what we were used to in Angular 1.x), or reactive. We're going to explore the absolute fundamentals of the template-driven Angular 2 forms, covering `ngForm`, `ngModel`, `ngModelGroup`, submit events, validation and error messages.
+Angular (v2+) presents two different methods for creating forms, template-driven (what we were used to in AngularJS 1.x), or reactive. We're going to explore the absolute fundamentals of the template-driven Angular forms, covering `ngForm`, `ngModel`, `ngModelGroup`, submit events, validation and error messages.
 
 ### Table of contents
 
@@ -29,7 +29,7 @@ Before we begin, let's clarify what "template-driven" forms mean from a high lev
 
 #### Template-driven
 
-When we talk about "template-driven" forms, we'll actually be talking about the kind of forms we're used to with Angular 1.x, whereby we bind directives and behaviour to our templates, and let Angular roll with it. Examples of these directives we'd use are `ngModel` and perhaps `required`, `minlength` and so forth. On a high-level, this is what template-driven forms achieve for us - by specifying directives to bind our models, values, validation and so on, we are letting the template do the work under the scenes.
+When we talk about "template-driven" forms, we'll actually be talking about the kind of forms we're used to with AngularJS, whereby we bind directives and behaviour to our templates, and let Angular roll with it. Examples of these directives we'd use are `ngModel` and perhaps `required`, `minlength` and so forth. On a high-level, this is what template-driven forms achieve for us - by specifying directives to bind our models, values, validation and so on, we are letting the template do the work under the scenes.
 
 ### Form base and interface
 
@@ -372,7 +372,7 @@ Here we're using Object destructuring to fetch the `value` and `valid` propertie
 
 #### Template-driven error validation
 
-Oh la la, the fancy bits. To roll out some validation is actually very similar to how we'd approach this in Angular 1.x as well (hooking into individual form field validation properties).
+Oh la la, the fancy bits. To roll out some validation is actually very similar to how we'd approach this in AngularJS 1.x as well (hooking into individual form field validation properties).
 
 First off, let's start simple and disable our submit button until the form's valid:
 

--- a/_posts/2016-10-19-angular-2-forms-reactive.md
+++ b/_posts/2016-10-19-angular-2-forms-reactive.md
@@ -7,7 +7,7 @@ tags:
 - Angular 2
 ---
 
-Angular 2 presents two different methods for creating forms, template-driven (what we were used to in Angular 1.x), or reactive. We're going to explore the absolute fundamentals of the reactive Angular 2 forms, covering `ngForm`, `ngModel`, `ngModelGroup`, submit events, validation and error messages.
+Angular (v2+) presents two different methods for creating forms, template-driven (what we were used to in AngularJS 1.x), or reactive. We're going to explore the absolute fundamentals of the reactive Angular forms, covering `ngForm`, `ngModel`, `ngModelGroup`, submit events, validation and error messages.
 
 ### Table of contents
 

--- a/_posts/2016-10-26-reactive-formgroup-validation-angular-2.md
+++ b/_posts/2016-10-26-reactive-formgroup-validation-angular-2.md
@@ -7,7 +7,7 @@ tags:
 - Angular 2
 ---
 
-Validation in Angular 2, various approaches, various APIs to use. We're going to use `AbstractControl` to learn how to validate a particular `FormGroup`. I covered `FormGroup`, `FormControl` and `FormBuilder` in my previous [reactives form](/angular-2-forms-reactive) fundamentals article - which I'd recommend checking out before this one if you're new to Angular 2 forms.
+Validation in Angular (v2+), various approaches, various APIs to use. We're going to use `AbstractControl` to learn how to validate a particular `FormGroup`. I covered `FormGroup`, `FormControl` and `FormBuilder` in my previous [reactives form](/angular-2-forms-reactive) fundamentals article - which I'd recommend checking out before this one if you're new to Angular forms.
 
 ### Table of contents
 
@@ -271,7 +271,7 @@ import { emailMatcher } from './email-matcher';
 ...
 {% endhighlight %}
 
-> Note: Angular 2 doesn't have built-in `type=email` validation anymore, however you've just learned how to implement your own with `AbstractControl`, swap it out for `FormControl` when validating on a single `FormControl` :)
+> Note: Angular doesn't have built-in `type=email` validation anymore; however, you've just learned how to implement your own with `AbstractControl`, swap it out for `FormControl` when validating on a single `FormControl` :)
 
 Everything is now hooked up, try out the code below for the working demo :)
 

--- a/_posts/2016-11-04-modern-angular-interview-questions.md
+++ b/_posts/2016-11-04-modern-angular-interview-questions.md
@@ -5,7 +5,7 @@ title: Modern Angular 1.x essential interview questions
 path: 2016-11-04-modern-angular-interview-questions.md
 ---
 
-Angular 1.x has changed a lot with 1.5 introducing `.component()`, and with this it brings a whole new light to interviewing. At many previous jobs I've interviewed many developers on Angular, JavaScript in general and combining the two. This is my list of what I'd consider "modern Angular 1.x" interview questions, with a focus on component architecture and modern "best practices". Some are easy, some are hard - take your pick!
+AngularJS 1.x has changed a lot with version 1.5 introducing `.component()`, and with this it brings a whole new light to interviewing. At many previous jobs I've interviewed many developers on Angular, JavaScript in general and combining the two. This is my list of what I'd consider "modern AngularJS 1.x" interview questions, with a focus on component architecture and modern "best practices". Some are easy, some are hard - take your pick!
 
 Some questions are geared towards letting the interviewee decide approaches and answer based on their experience/opinions. For instance, "when would you use X over Y" is a better question than "why is X a better approach than Y?". This allows you to dig deeper and also have better conversations during the interview - as well as quickly gauge whether the developer is right for you.
 
@@ -33,18 +33,18 @@ Some questions are geared towards letting the interviewee decide approaches and 
 * _What benefits does unidirectional dataflow bring?_
 * _What are common problems with multidirectional dataflow?_
 * _Have you ever used `$ngRedux` or a similar implementation?_
-* _What benefits does a Redux approach with Angular 1.x bring?_
+* _What benefits does a Redux approach with AngularJS bring?_
 
 ### Performance and debugging
 
 * _What are key areas you can address for faster `$digest` cycles?_
 * _What are the benefits to using one-time binding expressions?_
-* _What can lead to memory leaks in Angular 1.x?_
+* _What can lead to memory leaks in AngularJS?_
 * _How would you speed up an `ng-repeat`?_
 * _How does `track by` work?_
 * _What are `$evalAsync` and `$applyAsync`?_
 * _What are the differences between `$watch` and `$watchCollection`?_
-* _Explain how you would attempt to debug an Angular 1.x performance issue_
+* _Explain how you would attempt to debug an AngularJS performance issue_
 * _What debugging tools are you familiar with?_
 * _What is `strict-di` mode and how does it affect runtime performance?_
 * _What tools have you used to make Angular faster?_
@@ -92,7 +92,7 @@ Some questions are geared towards letting the interviewee decide approaches and 
 
 * _How would you implement form validation using the form's controller?_
 * _What do `dirty`, `pristine`, `touched` and `untouched` mean?_
-* _What limitations do Angular 1.x forms have?_
+* _What limitations do AngularJS forms have?_
 * _What are some of the built-in validators?_
 * _What are `$parsers` and `$formatters`, and when should you use them?
 * _What is the `$validators` pipeline, and when should you use it?
@@ -143,7 +143,7 @@ Some questions are geared towards letting the interviewee decide approaches and 
 
 ### Events
 
-* _When should you use events in Angular 1.x?_
+* _When should you use events in AngularJS?_
 * _What's the difference between `$emit` and `$broadcast`?_
 * _What's the difference between `$scope.$emit` and `$rootScope.$emit`?_
 * _How does event unbinding differ in `$scope` and `$rootScope`?_

--- a/_posts/2016-11-16-patch-value-versus-set-value-angular-2-forms.md
+++ b/_posts/2016-11-16-patch-value-versus-set-value-angular-2-forms.md
@@ -7,7 +7,7 @@ tags:
 - Angular 2
 ---
 
-Setting model values in Angular 2 can be done in a few different ways, however with [reactive forms](/angular-2-forms-reactive) things are extremely easy to do with the new form APIs. In this post we'll dig a little deeper as to the differences between `patchValue` and `setValue` in Angular 2 forms.
+Setting model values in Angular (v2+) can be done in a few different ways, however with [reactive forms](/angular-2-forms-reactive) things are extremely easy to do with the new form APIs. In this post we'll dig a little deeper as to the differences between `patchValue` and `setValue` in Angular forms.
 
 ### Reactive Form Setup
 
@@ -139,7 +139,7 @@ ngOnInit() {
 }
 {% endhighlight %}
 
-So anytime the route params change, we can use our `getSurvey` method, pass in the current param in the URL (the unique `:id`) and go fetch that unique Object. In this case, I've been using AngularFire2 which returns a `FirebaseObjectObservable`, therefore I can pipe it through `switchMap` and get the data through the `subscribe`. 
+So anytime the route params change, we can use our `getSurvey` method, pass in the current param in the URL (the unique `:id`) and go fetch that unique Object. In this case, I've been using AngularFire2 which returns a `FirebaseObjectObservable`, therefore I can pipe it through `switchMap` and get the data through the `subscribe`.
 
 The next question: `patchValue` or `setValue`? Before using an API I've gotten into the good habit of looking through the source code, so let's quickly run over the difference between the two:
 
@@ -367,7 +367,7 @@ this.survey.controls['account'].patchValue(survey.account);
 this.survey.controls['account'].setValue(survey.account);
 {% endhighlight %}
 
-These are in the Angular 2 docs, but the source code often makes more sense of what's really happening.
+These are in the Angular docs, but the source code often makes more sense of what's really happening.
 
 ### Source code
 

--- a/_posts/2016-11-17-dynamic-page-titles-angular-2-router-events.md
+++ b/_posts/2016-11-17-dynamic-page-titles-angular-2-router-events.md
@@ -7,11 +7,11 @@ tags:
 - Angular 2
 ---
 
-Updating page titles in Angular 1.x was a little problematic and typically was done via a global `$rootScope` property that listened for route change events to fetch the current route and map across a static page title. In Angular 2, the solution is far easier as it provides a single API, however we can actually tie this API into route change events to dynamically update the page titles. 
+Updating page titles in AngularJS (1.x) was a little problematic and typically was done via a global `$rootScope` property that listened for route change events to fetch the current route and map across a static page title. In Angular (v2+), the solution is far easier as it provides a single API, however we can actually tie this API into route change events to dynamically update the page titles.
 
 ### Title Service
 
-In Angular 2, we can request the `Title` from `platform-browser` (we're also going to import the `router` too):
+In Angular, we can request the `Title` from `platform-browser` (we're also going to import the `router` too):
 
 {% highlight javascript %}
 import { Title } from '@angular/platform-browser';
@@ -68,10 +68,10 @@ export class AppComponent implements OnInit {
 }
 {% endhighlight %}
 
-One thing I liked about [ui-router](https://github.com/angular-ui/ui-router) in Angular 1.x was the ability to add a custom `data: {}` Object to each route, which could be inherited down the chain of router states:
+One thing I liked about [ui-router](https://github.com/angular-ui/ui-router) in AngularJS was the ability to add a custom `data: {}` Object to each route, which could be inherited down the chain of router states:
 
 {% highlight javascript %}
-// Angular 1.x + ui-router
+// AngularJS 1.x + ui-router
 .config(function ($stateProvider) {
   $stateProvider
     .state('about', {
@@ -84,7 +84,7 @@ One thing I liked about [ui-router](https://github.com/angular-ui/ui-router) in 
 });
 {% endhighlight %}
 
-In Angular 2 we can do the exact same however we need to add some custom logic around route changes to get it working. First, assume the following routes in a pseudo-calendar application:
+In Angular we can do the exact same however we need to add some custom logic around route changes to get it working. First, assume the following routes in a pseudo-calendar application:
 
 {% highlight javascript %}
 const routes: Routes = [{
@@ -145,7 +145,7 @@ this.router.events
   });
 {% endhighlight %}
 
-This is a fine approach, but because the Angular 2 router is reactive, we'll implement more logic using RxJS, let's import:
+This is a fine approach, but because the Angular router is reactive, we'll implement more logic using RxJS, let's import:
 
 {% highlight javascript %}
 import 'rxjs/add/operator/filter';

--- a/_posts/2016-12-06-angular-1-6.md
+++ b/_posts/2016-12-06-angular-1-6.md
@@ -5,7 +5,7 @@ title: Angular 1.6 is here, this is what you need to know
 path: 2016-12-06-angular-1-6.md
 ---
 
-Angular 1.6 [just got released](https://github.com/angular/angular.js/blob/master/CHANGELOG.md#160-rainbow-tsunami-2016-12-08)! Here's the low down on what to expect for the [component method](/exploring-the-angular-1-5-component-method/) changes as well as `$http` Promise method deprecations and the amazing new `ngModelOptions` inheritance feature.
+AngularJS 1.6 [just got released](https://github.com/angular/angular.js/blob/master/CHANGELOG.md#160-rainbow-tsunami-2016-12-08)! Here's the low down on what to expect for the [component method](/exploring-the-angular-1-5-component-method/) changes as well as `$http` Promise method deprecations and the amazing new `ngModelOptions` inheritance feature.
 
 > The purpose of this article is to focus on the most important changes, `$onInit` and `ngModelOptions` inheritance.
 
@@ -28,7 +28,7 @@ The [official](https://docs.angularjs.org/guide/migration) documentation guides 
 
 ### Component and $onInit
 
-Let's begin with the most important update and recommendation if you're using Angular 1.5 components and their [lifecycle hooks](/angular-1-5-lifecycle-hooks).
+Let's begin with the most important update and recommendation if you're using AngularJS 1.5 components and their [lifecycle hooks](/angular-1-5-lifecycle-hooks).
 
 #### Initialisation logic
 
@@ -113,9 +113,9 @@ Using `$onInit` guarantees that the `bindings` are assigned before using them.
 
 #### $onInit and ngOnInit
 
-Let's look at an Angular 1.x and Angular 2 comparison momentarily before we step back to 1.6 as this will add some reason behind this change.
+Let's look at an AngularJS 1.x and Angular v2+ comparison momentarily before we step back to 1.6 as this will add some reason behind this change.
 
-Assume our Angular 1.x component using an ES6 class:
+Assume our AngularJS component using an ES6 class:
 
 {% highlight javascript %}
 const mortgageForm = {
@@ -132,7 +132,7 @@ const mortgageForm = {
 };
 {% endhighlight %}
 
-In Angular 2, we'd do the following:
+In Angular, we'd do the following:
 
 {% highlight javascript %}
 @Component({
@@ -147,7 +147,7 @@ class MortgageComponent implements OnInit {
 }
 {% endhighlight %}
 
-This approach treats the `constructor` function as the "wiring" of dependencies to be injected, be it Angular 1.x or Angular 2. If you're planning to upgrade your codebase, then adopting this strategy as early as possible is a huge win.
+This approach treats the `constructor` function as the "wiring" of dependencies to be injected, be it AngularJS or Angular. If you're planning to upgrade your codebase, then adopting this strategy as early as possible is a huge win.
 
 #### Re-enabling auto-bindings
 
@@ -301,10 +301,10 @@ Using `ngModelOptions` allows you to specify how a particular model updates, any
 An example:
 
 {% highlight html %}
-<input 
-  type="text" 
-  name="fullname" 
-  ng-model="$ctrl.applicant.name" 
+<input
+  type="text"
+  name="fullname"
+  ng-model="$ctrl.applicant.name"
   ng-model-options="{
     'updateOn': 'default blur',
     'debounce': {
@@ -323,10 +323,10 @@ Similarly, the `blur` is set to `0`, meaning we want to ensure the models are ch
 Using `ngModelOptions` is the _best_ performance enhancement you can give your inputs, but when you have multiple `<input>` nodes, you end up with something like this:
 
 {% highlight html %}
-<input 
-  type="text" 
-  name="fullname" 
-  ng-model="$ctrl.applicant.name" 
+<input
+  type="text"
+  name="fullname"
+  ng-model="$ctrl.applicant.name"
   ng-model-options="{
     'updateOn': 'default blur',
     'debounce': {
@@ -334,10 +334,10 @@ Using `ngModelOptions` is the _best_ performance enhancement you can give your i
       'blur': 0
     }
   }">
-<input 
-  type="email" 
-  name="email" 
-  ng-model="$ctrl.applicant.email" 
+<input
+  type="email"
+  name="email"
+  ng-model="$ctrl.applicant.email"
   ng-model-options="{
     'updateOn': 'default blur',
     'debounce': {
@@ -345,10 +345,10 @@ Using `ngModelOptions` is the _best_ performance enhancement you can give your i
       'blur': 0
     }
   }">
-<input 
-  type="text" 
-  name="postcode" 
-  ng-model="$ctrl.applicant.postcode" 
+<input
+  type="text"
+  name="postcode"
+  ng-model="$ctrl.applicant.postcode"
   ng-model-options="{
     'updateOn': 'default blur',
     'debounce': {
@@ -371,17 +371,17 @@ Let's take a look at that first example and refactor it, as we're using the same
   'updateOn': 'default blur',
   'debounce': { 'default': 200, 'blur': 0 }
 }">
-  <input 
-    type="text" 
-    name="fullname" 
+  <input
+    type="text"
+    name="fullname"
     ng-model="$ctrl.applicant.name">
-  <input 
-    type="email" 
-    name="email" 
+  <input
+    type="email"
+    name="email"
     ng-model="$ctrl.applicant.email">
-  <input 
-    type="text" 
-    name="postcode" 
+  <input
+    type="text"
+    name="postcode"
     ng-model="$ctrl.applicant.postcode">
 </form>
 {% endhighlight %}
@@ -403,9 +403,9 @@ Let's assume our _entire_ form is going to use the same options, however what we
   'debounce': { 'default': 200, 'blur': 0 }
 }">
   <!-- omitted other inputs for brevity -->
-  <input 
-    type="text" 
-    name="postcode" 
+  <input
+    type="text"
+    name="postcode"
     ng-model="$ctrl.applicant.postcode"
     ng-model-options="{
       '*': '$inherit',
@@ -425,9 +425,9 @@ We can also optionally choose to fallback to `ngModelOptions` default values (no
   'debounce': { 'default': 200, 'blur': 0 }
 }">
   <!-- omitted other inputs for brevity -->
-  <input 
-    type="text" 
-    name="postcode" 
+  <input
+    type="text"
+    name="postcode"
     ng-model="$ctrl.applicant.postcode"
     ng-model-options="{
       'updateOn': '$inherit'
@@ -445,6 +445,6 @@ You can obviously mix and match these for your specific use case, but these thre
 
 ### Migration / changelog
 
-Check the Angular [1.6 migration guide](https://docs.angularjs.org/guide/migration#migrating-from-1-5-to-1-6) for some of the other noteworthy enhancements (such as the improve `input[type=range]` support) - for me these were the big ones to ensure you're writing your 1.x applications with the most up-to-date practices.
+Check the Angular [1.6 migration guide](https://docs.angularjs.org/guide/migration#migrating-from-1-5-to-1-6) for some of the other noteworthy enhancements (such as the improve `input[type=range]` support) - for me these were the big ones to ensure you're writing your AngularJS applications with the most up-to-date practices.
 
-Huge shout out to [Pete Bacon Darwin](https://twitter.com/petebd) - lead Angular 1.x developer - and other collaborators that have been working on this release for so long. Angular 1.x is very much alive and it's direction is being steered not only towards Angular 2 practices, but better practices in general.
+Huge shout out to [Pete Bacon Darwin](https://twitter.com/petebd) - lead AngularJS developer - and other collaborators that have been working on this release for so long. Angular 1.x is very much alive and it's direction is being steered not only towards Angular practices, but better practices in general.

--- a/_posts/2016-12-13-building-tesla-battery-calculator-angular-2-reactive-forms.md
+++ b/_posts/2016-12-13-building-tesla-battery-calculator-angular-2-reactive-forms.md
@@ -5,7 +5,7 @@ title: Building Tesla&#39;s battery range calculator with Angular 2 reactive for
 path: 2016-12-13-building-tesla-range-calculator-angular-2-reactive-forms.md
 ---
 
-In this epic tutorial, we're going to build some advanced Angular 2 components that rebuild [Tesla's battery range calculator](https://tesla.com/en_GB/models#battery-options) and then compile it to [AoT](https://angular.io/docs/ts/latest/cookbook/aot-compiler.html) and deploy on GitHub pages. We'll be using the [reactive forms](/angular-2-forms-reactive) API as well and building custom form controls and use some stateful and stateless component practices, as well as change detection strategies.
+In this epic tutorial, we're going to build some advanced Angular (v2+) components that rebuild [Tesla's battery range calculator](https://tesla.com/en_GB/models#battery-options) and then compile it to [AoT](https://angular.io/docs/ts/latest/cookbook/aot-compiler.html) and deploy on GitHub pages. We'll be using the [reactive forms](/angular-2-forms-reactive) API as well and building custom form controls and use some stateful and stateless component practices, as well as change detection strategies.
 
 This is the final project `gif` of what we're about to build:
 
@@ -113,7 +113,7 @@ And then just drop all the images in there (and replace the `favicon.ico` in the
 
 First thing we'll do is create our sub-module, a feature specific module for handling our Tesla app.
 
-> Directories: Everything we're going to do with be inside `/src/app/` so any folder references will refer to in there 
+> Directories: Everything we're going to do with be inside `/src/app/` so any folder references will refer to in there
 
 #### Root @NgModule
 
@@ -224,7 +224,7 @@ The `Injectable` is a decorator from Angular that allows us to inject our servic
 
 ### Container and presentational components
 
-This is a new idea I'm currently working with in my Angular 2 apps, separating "container" and "presentational" components, otherwise known as [stateful and stateless components](/stateful-stateless-components) which I've previously written about, I'd urge you to check that out if you're up for further reading.
+This is a new idea I'm currently working with in my Angular apps, separating "container" and "presentational" components, otherwise known as [stateful and stateless components](/stateful-stateless-components) which I've previously written about, I'd urge you to check that out if you're up for further reading.
 
 The idea is that stateful components, which we'll refer to as "container" components in the rest of this tutorial, will live inside our module's `containers` directory. Any stateless components, i.e. presentational components, will just live inside `components`.
 
@@ -306,13 +306,13 @@ import { FormBuilder, FormGroup } from '@angular/forms';
       <h1>{% raw %}{{ title }}{% endraw %}</h1>
       <div class="tesla-battery__notice">
         <p>
-          The actual amount of range that you experience will vary based 
-          on your particular use conditions. See how particular use conditions 
+          The actual amount of range that you experience will vary based
+          on your particular use conditions. See how particular use conditions
           may affect your range in our simulation model.
         </p>
         <p>
-          Vehicle range may vary depending on the vehicle configuration, 
-          battery age and condition, driving style and operating, environmental 
+          Vehicle range may vary depending on the vehicle configuration,
+          battery age and condition, driving style and operating, environmental
           and climate conditions.
         </p>
       </div>
@@ -321,7 +321,7 @@ import { FormBuilder, FormGroup } from '@angular/forms';
   styleUrls: ['./tesla-battery.component.scss']
 })
 export class TeslaBatteryComponent implements OnInit {
-  
+
   title: string = 'Range Per Charge';
   tesla: FormGroup;
 
@@ -475,7 +475,7 @@ tesla-car.component.scss
 This is what will produce our car image and make the wheels spin:
 
 {% highlight javascript %}
-/* 
+/*
  * tesla-car.component.ts
  */
 import { Component, Input, ChangeDetectionStrategy } from '@angular/core';
@@ -792,14 +792,14 @@ We've already dependency injected the `FormBuilder`, so now it's time to add our
 // tesla-battery.component.ts
 @Component({...})
 export class TeslaBatteryComponent implements OnInit {
-  
+
   title: string = 'Range Per Charge';
   models: any;
   stats: Stat[];
   tesla: FormGroup;
-  
+
   private results: Array<String> = ['60', '60D', '75', '75D', '90D', 'P100D'];
-  
+
   constructor(public fb: FormBuilder, private batteryService: BatteryService) {}
   ...
   ...
@@ -833,7 +833,7 @@ Now into the `ngOnInit`, ensure yours looks like this:
 ngOnInit() {
 
   this.models = this.batteryService.getModelData();
-  
+
   this.tesla = this.fb.group({
     config: this.fb.group({
       speed: 55,
@@ -902,7 +902,7 @@ import { Component, Input, ChangeDetectionStrategy, forwardRef } from '@angular/
 // importing necessary accessors
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 
-// NUMBER_CONTROL_ACCESSOR constant to allow us to use the "TeslaCounterComponent" as 
+// NUMBER_CONTROL_ACCESSOR constant to allow us to use the "TeslaCounterComponent" as
 // a custom provider to the component and enforce the ControlValueAccessor interface
 const NUMBER_CONTROL_ACCESSOR = {
   provide: NG_VALUE_ACCESSOR,
@@ -919,7 +919,7 @@ const NUMBER_CONTROL_ACCESSOR = {
     <div class="tesla-counter">
       <p class="tesla-counter__title">{% raw %}{{ title }}{% endraw %}</p>
       <div class="tesla-counter__container cf">
-        <div 
+        <div
           class="tesla-counter__item"
           (keydown)="onKeyUp($event)"
           (blur)="onBlur($event)"
@@ -973,7 +973,7 @@ export class TeslaCounterComponent implements ControlValueAccessor {
     // assigns to our internal model change method
     this.onModelChange = fn;
   }
-  
+
   // called by the reactive form control
   registerOnTouched(fn: Function) {
     // assigns our own "touched" method
@@ -1174,7 +1174,7 @@ Let's jump back into our `tesla-battery.component.ts` and add our custom form co
         <div class="tesla-climate cf">
           <tesla-counter
             [title]="'Outside Temperature'"
-            [unit]="'°'" 
+            [unit]="'°'"
             [step]="10"
             [min]="-10"
             [max]="40"
@@ -1230,14 +1230,14 @@ const CHECKBOX_VALUE_ACCESSOR = {
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div class="tesla-climate">
-      <label 
+      <label
         class="tesla-climate__item"
         [class.tesla-heat]="!limit"
         [class.tesla-climate__item--active]="value"
         [class.tesla-climate__item--focused]="focused === value">
         <p>{% raw %}{{ (limit ? 'ac' : 'heat') }}{% endraw %} {% raw %}{{ value ? 'on' : 'off' }}{% endraw %}</p>
         <i class="tesla-climate__icon"></i>
-      <input 
+      <input
         type="checkbox"
         name="climate"
         [checked]="value"
@@ -1292,7 +1292,7 @@ export class TeslaClimateComponent implements ControlValueAccessor {
 We're pretty much doing the same thing as the previous component, however we're directly writing the `value` property to a `checkbox` as seen here:
 
 {% highlight html %}
-<input 
+<input
   type="checkbox"
   name="climate"
   [checked]="value"
@@ -1418,14 +1418,14 @@ Let's jump back into our `tesla-battery.component.ts` and add our custom form `t
         <div class="tesla-climate cf">
           <tesla-counter
             [title]="'Outside Temperature'"
-            [unit]="'°'" 
+            [unit]="'°'"
             [step]="10"
             [min]="-10"
             [max]="40"
             formControlName="temperature">
           </tesla-counter>
-          <tesla-climate 
-            [limit]="tesla.get('config.temperature').value > 10" 
+          <tesla-climate
+            [limit]="tesla.get('config.temperature').value > 10"
             formControlName="climate">
           </tesla-climate>
         </div>
@@ -1478,12 +1478,12 @@ const RADIO_CONTROL_ACCESSOR = {
     <div class="tesla-wheels">
       <p class="tesla-wheels__title">Wheels</p>
       <div class="tesla-wheels__container cf">
-        <label 
+        <label
           *ngFor="let size of sizes;"
           class="tesla-wheels__item tesla-wheels__item--{% raw %}{{ size }}{% endraw %}"
           [class.tesla-wheels__item--active]="value === size"
           [class.tesla-wheels__item--focused]="focused === size">
-          <input 
+          <input
             type="radio"
             name="wheelsize"
             [attr.value]="size"
@@ -1641,14 +1641,14 @@ This one's an easy addition to our `tesla-battery.component.ts` (ensure it's out
         <div class="tesla-climate cf">
           <tesla-counter
             [title]="'Outside Temperature'"
-            [unit]="'°'" 
+            [unit]="'°'"
             [step]="10"
             [min]="-10"
             [max]="40"
             formControlName="temperature">
           </tesla-counter>
-          <tesla-climate 
-            [limit]="tesla.get('config.temperature').value > 10" 
+          <tesla-climate
+            [limit]="tesla.get('config.temperature').value > 10"
             formControlName="climate">
           </tesla-climate>
         </div>
@@ -1704,7 +1704,7 @@ You should have a fully working Tesla range calculator:
 
 ### Deploying with Ahead-of-Time compilation
 
-AoT means Angular will precompile everything (including our templates) and give us the bare minimum Angular 2 needs for our application. I'm getting around `313 KB` for this entire project, including images, fonts. `184 KB` of that is Angular 2 code!
+AoT means Angular will precompile everything (including our templates) and give us the bare minimum Angular needs for our application. I'm getting around `313 KB` for this entire project, including images, fonts. `184 KB` of that is Angular code!
 
 #### Deploying to GitHub pages
 

--- a/_posts/2017-01-20-should-you-learn-angular-1-or-angular-2.md
+++ b/_posts/2017-01-20-should-you-learn-angular-1-or-angular-2.md
@@ -21,27 +21,27 @@ First thing to remember, there is no "official" answer (though the short and con
 
 Regardless of whether you are working solo, or in a team, if you're currently in a job, here's some thoughts on answering the question.
 
-Firstly, Angular 1.x is the dominant predator of the framework world, it's likely the biggest and most used framework currently out there being used in the wild. If you're in a job using 1.x, that is not an issue. If your company is building a single product/application for a customer, then you'll likely want to heads-down focus on your project deliverables and keep iterating your project.
+Firstly, AngularJS (1.x) is the dominant predator of the framework world, it's likely the biggest and most used framework currently out there being used in the wild. If you're in a job using AngularJS, that is not an issue. If your company is building a single product/application for a customer, then you'll likely want to heads-down focus on your project deliverables and keep iterating your project.
 
-Secondly, why would you want to rewrite those potentially years of hard work, just to upgrade your codebase? There are several factors that may come into play when answering this question. Angular 1.x has been around since 2009, and despite being an extremely productive and fast framework, there are several limitations that can hinder it's potential lifespan in your project. But this isn't something to hit the panic button about and move directly to Angular 2.
+Secondly, why would you want to rewrite those potentially years of hard work, just to upgrade your codebase? There are several factors that may come into play when answering this question. AngularJS has been around since 2009, and despite being an extremely productive and fast framework, there are several limitations that can hinder it's potential lifespan in your project. But this isn't something to hit the panic button about and move directly to Angular (v2+).
 
 Regardless of how you decide, remember - you are essentially switching frameworks. It's not an "upgrade" or "migration" - you are moving to an entirely different codebase (either big bang style rewrite or incremental). A CEO/CTO is not going to simply want a rewrite without solid clarification as to why, and the business impact costs of doing so. For them, delivering for their customers are the key focus, not your version number.
 
 #### Scenario: Single Product company
 
-So what am I getting at? Let's take GitHub for example, and assume they are using Angular 1.x. The codebase may be several years old, but now they want to share their codebase to deploy to mobile, or distribute on desktop clients as well. They are stuck with a few options - such as writing standalone mobile applications (likely Android/iOS), and also building a native desktop client. These are skillset differences that require more monetary investment.
+So what am I getting at? Let's take GitHub for example, and assume they are using AngularJS. The codebase may be several years old, but now they want to share their codebase to deploy to mobile, or distribute on desktop clients as well. They are stuck with a few options - such as writing standalone mobile applications (likely Android/iOS), and also building a native desktop client. These are skillset differences that require more monetary investment.
 
-A business objective that, in my opinion, would encourage my employer to move to Angular 2, is to allow for all of the above to be done in a single framework. With Angular 2, you can compile to native mobile code with NativeScript, deploy to mobile with Ionic and use Electron for desktop. Single codebase.
+A business objective that, in my opinion, would encourage my employer to move to Angular, is to allow for all of the above to be done in a single framework. With Angular, you can compile to native mobile code with NativeScript, deploy to mobile with Ionic and use Electron for desktop. Single codebase.
 
-But let's step back - what about your main web application? A single page app (SPA) can be fast if you're chunking your code, minifying and following great performance tactics and shipping content to users as fast as possible, however - it can be faster. Angular 2 can be server-side rendered (SSR) via Angular Universal, where Angular 1.x cannot. This is another selling point on whether you should learn Angular 2 or not.
+But let's step back - what about your main web application? A single page app (SPA) can be fast if you're chunking your code, minifying and following great performance tactics and shipping content to users as fast as possible, however - it can be faster. Angular can be server-side rendered (SSR) via Angular Universal, where Angular 1.x cannot. This is another selling point on whether you should learn Angular or not.
 
 #### Scenario: Multi-Product and Green Field
 
-I've worked on both single product applications in Angular 1.x, as well as building several projects in 1.x for companies during the last few years - so I've had a taste of both sides of the coin. Let's assume that you have 10 great clients and 10 Angular 1.x apps, and client number 11 comes along offering an opportunity for a green field, fresh start product. What do you do?
+I've worked on both single product applications in AngularJS, as well as building several projects in 1.x for companies during the last few years - so I've had a taste of both sides of the coin. Let's assume that you have 10 great clients and 10 Angular 1.x apps, and client number 11 comes along offering an opportunity for a green field, fresh start product. What do you do?
 
-For future-proofing, a great consideration at this point is Angular 2, because of some of the items listed above. Angular 2 was also rewritten from scratch and focuses on best practices that have been established through one-way dataflow and component architecture. You can do these things in Angular 1.x, however they have only (really) recently landed. Which means more refactoring of your existing codebase(s) to upgrade to using 1.6+ and the [.component](/exploring-the-angular-1-5-component-method/) API.
+For future-proofing, a great consideration at this point is Angular, because of some of the items listed above. Angular 2 was also rewritten from scratch and focuses on best practices that have been established through one-way dataflow and component architecture. You can do these things in AngularJS, however they have only (really) recently landed. Which means more refactoring of your existing codebase(s) to upgrade to using 1.6+ and the [.component](/exploring-the-angular-1-5-component-method/) API.
 
-There is no doubt that Angular 1.x will be "discontinued" in the coming years, but then again - won't all of our apps and versions? You don't have to use the latest and greatest, but after 3 hard years Angular 2 finally shipped and it's incredible power is certainly worth investigating.
+There is no doubt that AngularJS will be "discontinued" in the coming years, but then again - won't all of our apps and versions? You don't have to use the latest and greatest, but after 3 hard years Angular finally shipped and it's incredible power is certainly worth investigating.
 
 If client number 11 wants a new application from you, then go for it. But first, you need to understand things like [lifecycle hooks](/angular-1-5-lifecycle-hooks), [stateful and stateless](/stateful-stateless-components) components as well as [one-way dataflow and events](https://github.com/toddmotto/angular-styleguide#one-way-dataflow-and-events).
 
@@ -49,32 +49,32 @@ If client number 11 wants a new application from you, then go for it. But first,
 
 There are a few scenarios again here, and they all differ from person to person based on what _you_ are doing. There is no silver bullet answer.
 
-#### Scenario: Employed using 1.x
+#### Scenario: Employed using AngularJS
 
-If you're using Angular 1.x at work, it's likely you've already looked at Angular 2 and poked around the documentation and realised it is a different beast to Angular 1.x and the MVC patterns you were once used to. At this point - it is completely up to you. If you want to dive deeper into Angular 2 - go for it! If you don't, that's absolutely fine too. There is no point asking someone's advice on whether you should or shouldn't, unless you have a specific reason for the question (i.e. can I render on the server, or do XYZ?). It's like asking "Should I buy a Porsche or a Ferrari?" - the answer is in your head only.
+If you're using AngularJS at work, it's likely you've already looked at Angular and poked around the documentation and realised it is a different beast to AngularJS and the MVC patterns you were once used to. At this point - it is completely up to you. If you want to dive deeper into Angular - go for it! If you don't, that's absolutely fine too. There is no point asking someone's advice on whether you should or shouldn't, unless you have a specific reason for the question (i.e. can I render on the server, or do XYZ?). It's like asking "Should I buy a Porsche or a Ferrari?" - the answer is in your head only.
 
-This doesn't mean that outside of work - you cannot learn Angular 2 and bring a pitch to your boss if you wanted to move to Angular 2. Learn it in your own time and see if you like it - it's that simple.
+This doesn't mean that outside of work - you cannot learn Angular and bring a pitch to your boss if you wanted to move to Angular. Learn it in your own time and see if you like it - it's that simple.
 
 #### Scenario: New to Angular
 
-If you're completely new to Angular, this is a tricky question. Based on the above monolithic marketshare that Angular 1.x has, and company adoption rates of Angular 2 - you may have to learn both. If you learn Angular 1.x with the `.component()` API, and at least understand how to "go back to the MVC way", then you can walk into a job tomorrow with a company using Angular 1.x.
+If you're completely new to Angular, this is a tricky question. Based on the above monolithic marketshare that AngularJS has, and company adoption rates of Angular - you may have to learn both. If you learn AngularJS with the `.component()` API, and at least understand how to "go back to the MVC way", then you can walk into a job tomorrow with a company using AngularJS.
 
-That being said - if you are looking for an "Angular 2 only" job, those are quite hard to come by right now, as per all the reasons listed above. If you are new to Angular, you may need to learn both, but again you'll have to decide that for yourself based on your own goals in life and your career.
+That being said - if you are looking for an "Angular only" job, those are quite hard to come by right now, as per all the reasons listed above. If you are new to Angular, you may need to learn both, but again you'll have to decide that for yourself based on your own goals in life and your career.
 
-Angular 2 is rapidly growing, and the growth is _phenomenal_, however this doesn't mean you can ping your new CV round a bunch of companies with just "Angular 2+" listed as a job spec. It's likely many companies still, and for years to come, will be using Angular 1.x. In this case, you need to decide what job you want, what skills you want, and where you want to be hired. I am generalising here a lot and assuming everyone reading this is "employed" - but there are many self-employed folks, like me, that also have to deal with this question.
+Angular is rapidly growing, and the growth is _phenomenal_, however this doesn't mean you can ping your new CV round a bunch of companies with just "Angular 2+" listed as a job spec. It's likely many companies still, and for years to come, will be using AngularJS. In this case, you need to decide what job you want, what skills you want, and where you want to be hired. I am generalising here a lot and assuming everyone reading this is "employed" - but there are many self-employed folks, like me, that also have to deal with this question.
 
-If you're a self-employed engineer, you obviously need to fender for yourself and "put food on the table". Let's assume you have 50 requests for 1.x apps, and 1 request for Angular 2 apps - which are you going to focus more time on? Angular 1.x.
+If you're a self-employed engineer, you obviously need to fender for yourself and "put food on the table". Let's assume you have 50 requests for AngularJS apps, and one request for Angular apps - which are you going to focus more time on? AngularJS.
 
-On the flip side, you may be in a position where you're getting 50/50 requests for new work, consultancy or whatever it is you're doing - and therefore you'll have to learn both. Most Angular 2 developers I personally know all know Angular 1.x as well, as we've been using it for years.
+On the flip side, you may be in a position where you're getting 50/50 requests for new work, consultancy or whatever it is you're doing - and therefore you'll have to learn both. Most Angular developers I personally know all know AngularJS as well, as we've been using it for years.
 
 #### Scenario: Employed using something else
 
-Perhaps you're using something like React, Ember, Backbone, Knockout for example, and you're considering Angular 2. Firstly, you need to investigate what Angular 2 will _give you_. Things like [Ahead-of-Time](https://angular.io/docs/ts/latest/cookbook/aot-compiler.html) compilation to drastically decrease the size of your codebase before you even ship to the browser and deploy your app are key considerations to look for with Angular 2.
+Perhaps you're using something like React, Ember, Backbone, Knockout for example, and you're considering Angular. Firstly, you need to investigate what Angular 2 will _give you_. Things like [Ahead-of-Time](https://angular.io/docs/ts/latest/cookbook/aot-compiler.html) compilation to drastically decrease the size of your codebase before you even ship to the browser and deploy your app are key considerations to look for with Angular.
 
 ### Closing thoughts
 
-In a quick summary - it's all down to you and your job. Angular 2 jobs will be on the rise, and Angular 1.x jobs will still be around and rising no doubt, in fact the need for 1.x support in the enterprise (unless they decide to migrate) will be even higher.
+In a quick summary - it's all down to you and your job. Angular jobs will be on the rise, and AngularJS jobs will still be around and rising no doubt, in fact the need for AngularJS support in the enterprise (unless they decide to migrate) will be even higher.
 
-The tl:dr; answer to this is if you're using Angular 1.x, consider your future goals for the project(s) and company. If you are new to Angular and want a job, you need to investigate the market and companies you're approaching and what tech stack they'll likely be using.
+The tl:dr; answer to this is if you're using AngularJS, consider your future goals for the project(s) and company. If you are new to Angular and want a job, you need to investigate the market and companies you're approaching and what tech stack they'll likely be using.
 
 There is no right answer regardless, but hopefully this post has given you some decent insight as to what you need to consider. All the best with it!

--- a/_posts/2017-01-26-angular-decorators.md
+++ b/_posts/2017-01-26-angular-decorators.md
@@ -5,13 +5,13 @@ title: "A deep dive on Angular decorators"
 path: 2017-01-26-angular-decorators.md
 ---
 
-Decorators are a core concept when developing with Angular 2 and above. There's also an official [TC39 proposal](https://github.com/tc39/proposal-decorators), currently at Stage-2, so expect decorators to become a core language feature soon in JavaScript as well.
+Decorators are a core concept when developing with Angular (versions 2 and above). There's also an official [TC39 proposal](https://github.com/tc39/proposal-decorators), currently at Stage-2, so expect decorators to become a core language feature soon in JavaScript as well.
 
 Back to Angular, the internal codebase uses decorators extensively and in this post we’re going to look at the different types of decorators, the code they compile to and how they work.
 
 When I was first introduced to TypeScript and decorators, I wondered why we needed them at all, but once you dig a little deeper you can understand the benefits to creating decorators (not only for use in Angular).
 
-Angular 1.x didn't use decorators, opting for a different registration method - such as defining a component for example with the `.component()` method. So why has Angular 2+ chose to use them? Let's explore.
+AngularJS didn't use decorators, opting for a different registration method - such as defining a component for example with the `.component()` method. So why has Angular chose to use them? Let's explore.
 
 ### Table of contents
 
@@ -105,7 +105,7 @@ We'd then pass the input binding via a component property binding:
 
 The property decorator and "magic" happens _within_ the `ExampleComponent` definition.
 
-In Angular 1.x (I'm going to use TypeScript here also, just to declare a property on a class), we had a different mechanism using `scope` or `bindToController` with Directives, and `bindings` within the new [component method](/exploring-the-angular-1-5-component-method/):
+In AngularJS 1.x (I'm going to use TypeScript here also, just to declare a property on a class), we had a different mechanism using `scope` or `bindToController` with Directives, and `bindings` within the new [component method](/exploring-the-angular-1-5-component-method/):
 
 ```js
 const exampleComponent = {
@@ -128,7 +128,7 @@ angular
   .component('exampleComponent', exampleComponent);
 ```
 
-You can see above that we have two separate properties to maintain should we expand, refactor or change our component's API - `bindings` and the property name inside the class. However, in Angular 2+ there is a single property `exampleProperty` which is decorated, which is easier to change, maintain and track as our codebase grows.
+You can see above that we have two separate properties to maintain should we expand, refactor or change our component's API - `bindings` and the property name inside the class. However, in Angular there is a single property `exampleProperty` which is decorated, which is easier to change, maintain and track as our codebase grows.
 
 #### Method Decorators
 
@@ -245,7 +245,7 @@ We would need to adapt our `Console` decorator to return a function closure for 
 function Console(message) {
   // access the "metadata" message
   console.log(message);
-  // return a function closure, which 
+  // return a function closure, which
   // is passed the class as `target`
   return function (target) {
     console.log('Our decorated class', target);
@@ -369,15 +369,15 @@ export class TestComponent {
 ```
 
 At the same time, Angular also uses the reflect API (commonly polyfilled using `reflect-metadata`) to store these annotations, using the class as an array. This means that it can then later on fetch all of the annotations for a specific class just by being pointed to the class.
- 
+
 ### How decorators are applied
- 
+
 So we know now how and why Angular uses decorators, but how are they actually applied to a class?
 
 As mentioned, decorators aren't native to JavaScript just yet - TypeScript currently provides the functionality for us. This means that we can check the compiled code to see what actually happens when we use a decorator.
- 
+
 Take a standard, ES6 class -
- 
+
 ```js
 class ExampleClass {
   constructor() {

--- a/_posts/2017-02-01-angular-ngfor.md
+++ b/_posts/2017-02-01-angular-ngfor.md
@@ -81,10 +81,10 @@ import { Contact } from './models/contact.interface';
   `
 })
 export class ContactCardComponent {
-  
+
   @Input()
   contact: Contact;
-  
+
 }
 ```
 
@@ -198,7 +198,7 @@ You can check a live output of what we've covered so far here:
 
 #### Using trackBy for keys
 
-If you're coming from an Angular 1.x background, you'll have likely seen "track by" when using an `ng-repeat`, and similarly in React land, using `key` on a collection item.
+If you're coming from an AngularJS background, you'll have likely seen "track by" when using an `ng-repeat`, and similarly in React land, using `key` on a collection item.
 
 So what do these do? They associate the objects, or keys, with the particular DOM nodes, so should anything change or need to be re-rendered, the framework can do this much more efficiently. Angular's `ngFor` defaults to using _object identity_ checking for you, which is fast, but can be _faster_!
 
@@ -262,7 +262,7 @@ The `count` will return a live collection length, equivalent of `contacts.length
 ```html
 <ul>
   <li *ngFor="let contact of contacts | async; let i = index; let c = count;">
-    <contact-card 
+    <contact-card
       [contact]="contact"
       [collectionLength]="c"
       (update)="onUpdate($event, i)">
@@ -311,7 +311,7 @@ For this quick demo, we'll use `ngClass` to add some styles to each `<li>` (note
       'odd-active': o,
       'even-active': e
     }">
-    <contact-card 
+    <contact-card
       [contact]="contact"
       (update)="onUpdate($event, index)">
     </contact-card>
@@ -337,7 +337,7 @@ And some styles:
             'odd-active': o,
             'even-active': e
           }">
-          <contact-card 
+          <contact-card
             [contact]="contact"
             (update)="onUpdate($event, index)">
           </contact-card>
@@ -364,7 +364,7 @@ When using an asterisk (`*`) in our templates, we are informing Angular we're us
 
 #### &lt;template&gt; and Web Components
 
-So, what is the `<template>` element? First, let's take a step back. We'll roll back to showing some Angular 1.x code here, perhaps you've done this before or done something similar in another framework/library:
+So, what is the `<template>` element? First, let's take a step back. We'll roll back to showing some AngularJS code here, perhaps you've done this before or done something similar in another framework/library:
 
 ```html
 <script id="myTemplate" type="text/ng-template">
@@ -374,7 +374,7 @@ So, what is the `<template>` element? First, let's take a step back. We'll roll 
 </script>
 ```
 
-This overrides the `type` on the `<script>` tag, which prevents the JavaScript engine from parsing the contents of the `<script>` tag. This allows us, or a framework such as Angular 1.x, to fetch the contents of the script tag and use it as some form of HTML template.
+This overrides the `type` on the `<script>` tag, which prevents the JavaScript engine from parsing the contents of the `<script>` tag. This allows us, or a framework such as AngularJS, to fetch the contents of the script tag and use it as some form of HTML template.
 
 Web Components introduced something similar to this idea, called the `<template>`:
 


### PR DESCRIPTION
Here is a quick changelog.

# Global stuff

- In all articles, first occurrences of AngularJS and Angular have a clarification: AngularJS (1.x) and Angular (v2+). When a specific AngularJS version is mentioned, it's still there.
- There are places where you refer to "Angular" as an engine which has its own mind (scary), not as a version'd codebase/framework. In those cases, even when you talk about AngularJS, I've left it as "Angular". Just sounds better and is obvious from context.
- I didn't change static pages promoting your courses. I suggest you keep them until Angular 5 launches; by then people will hopefully release not to call it Angular 2. This also stands for links to your courses through your articles.
- Didn't change preamble in the posts either.
- Some articles are about AngularJS and just briefly mention Angular. In those cases I didn't only once state v2+, but repeated it if there was a long pause of not being mentioned. Just went with my senses here: if it looks like it could be confused with AngularJS, I put a v2+.
- Probably missed some stuff.

# Specific articles

- [2015-10-27](https://toddmotto.com/walkthrough-to-migrate-an-angular-1-component-to-angular-2/): Removed the note about Angular being alpha. I'm not familiar with AngularJS so no idea how much of the article is still relevant, though. There is definitely some deprecated Angular syntax there, but it's not trivial to fix.
- [2016-02-05](https://toddmotto.com/one-way-data-binding-in-angular-1-5/): This is tagged as `Angular 2`, dunno why.
- [2016-11-04](https://toddmotto.com/future-of-angular-1-x): Didn't bother with this one, it needs a more careful rewrite rather than renaming.
- [2016-11-10](https://toddmotto.com/please-stop-worrying-about-angular-3): Ditto.

# Things I've learned
- A bunch of new tricks
- AngularJS is/was scary
- Reading in British accent