### PR TITLE
Solved error for running on windows

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -18,6 +18,7 @@ const siteRoot = '_site';
 const jekyllLogger = buffer => {
   buffer.toString().split(/\n/).forEach((message) => util.log(`Jekyll: ${message}`));
 };
+const isWin = /^win/.test(process.platform);
 
 const banner = (
   `/*! toddmotto.com | Todd Motto (c) ${new Date().getFullYear()} */\n`
@@ -49,7 +50,7 @@ gulp.task('scripts', ['clean'], () => {
 });
 
 gulp.task('jekyll', () => {
-  const jekyll = child.spawn('jekyll', ['serve', '--watch', '--incremental', '--drafts']);
+  const jekyll = child.spawn(isWin ? 'jekyll.bat' : 'jekyll', ['serve', '--watch', '--incremental', '--drafts']);
   jekyll.stdout.on('data', jekyllLogger);
   jekyll.stderr.on('data', jekyllLogger);
 });


### PR DESCRIPTION
Running on windows gives following error:

Error: spawn jekyll ENOENT
    at exports._errnoException (util.js:1023:11)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:193:32)
    at onErrorNT (internal/child_process.js:359:16)
    at _combinedTickCallback (internal/process/next_tick.js:74:11)
    at process._tickCallback (internal/process/next_tick.js:98:9)
    at Module.runMain (module.js:607:11)
    at run (bootstrap_node.js:418:7)
    at startup (bootstrap_node.js:139:9)
    at bootstrap_node.js:533:3
error Command failed with exit code 1.

The issue has been resolved by the PR.